### PR TITLE
[FEAT] #8 - 네이버 OCR API 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // JSON
+    implementation 'org.springframework.boot:spring-boot-starter-json'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // JSON
     implementation 'org.springframework.boot:spring-boot-starter-json'
+    implementation 'org.json:json:20231013'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/sopt/seonyakServer/global/common/dto/OcrTextResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/dto/OcrTextResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.seonyakServer.global.common.dto;
+
+public record OcrTextResponse(
+        String univ
+) {
+    public static OcrTextResponse of(String univ) {
+        return new OcrTextResponse(univ);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/dto/OcrTextResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/dto/OcrTextResponse.java
@@ -1,9 +1,0 @@
-package org.sopt.seonyakServer.global.common.dto;
-
-public record OcrTextResponse(
-        String univ
-) {
-    public static OcrTextResponse of(String univ) {
-        return new OcrTextResponse(univ);
-    }
-}

--- a/src/main/java/org/sopt/seonyakServer/global/common/dto/OcrUnivResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/dto/OcrUnivResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.seonyakServer.global.common.dto;
+
+public record OcrUnivResponse(
+        String univName
+) {
+    public static OcrUnivResponse of(String univName) {
+        return new OcrUnivResponse(univName);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrConfig.java
@@ -1,0 +1,22 @@
+package org.sopt.seonyakServer.global.common.external.naver;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OcrConfig {
+    
+    @Value("${naver.ocr.api.url}")
+    private String apiUrl;
+
+    @Value("${naver.ocr.api.key}")
+    private String apiKey;
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrConfig.java
@@ -1,22 +1,17 @@
 package org.sopt.seonyakServer.global.common.external.naver;
 
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Getter
 public class OcrConfig {
-    
+
     @Value("${naver.ocr.api.url}")
     private String apiUrl;
 
     @Value("${naver.ocr.api.key}")
     private String apiKey;
-
-    public String getApiUrl() {
-        return apiUrl;
-    }
-
-    public String getApiKey() {
-        return apiKey;
-    }
+    
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
@@ -11,13 +11,13 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/ocr")
 @RequiredArgsConstructor
 public class OcrController {
 
     private final OcrService ocrService;
 
-    @PostMapping("/ocr")
+    @PostMapping("/univ")
     public ResponseEntity<OcrTextResponse> ocrText(@RequestParam("imageFile") MultipartFile file) throws IOException {
         return ResponseEntity.ok(ocrService.ocrText(file));
     }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
@@ -1,0 +1,24 @@
+package org.sopt.seonyakServer.global.common.external.naver;
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.global.common.dto.OcrTextResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OcrController {
+
+    private final OcrService ocrService;
+
+    @PostMapping("/ocr")
+    public ResponseEntity<OcrTextResponse> ocrText(@RequestParam("imageFile") MultipartFile file) throws IOException {
+        return ResponseEntity.ok(ocrService.ocrText(file));
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
@@ -2,7 +2,7 @@ package org.sopt.seonyakServer.global.common.external.naver;
 
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.sopt.seonyakServer.global.common.dto.OcrTextResponse;
+import org.sopt.seonyakServer.global.common.dto.OcrUnivResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +18,7 @@ public class OcrController {
     private final OcrService ocrService;
 
     @PostMapping("/univ")
-    public ResponseEntity<OcrTextResponse> ocrText(@RequestParam("imageFile") MultipartFile file) throws IOException {
+    public ResponseEntity<OcrUnivResponse> ocrText(@RequestParam("imageFile") MultipartFile file) throws IOException {
         return ResponseEntity.ok(ocrService.ocrText(file));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
@@ -9,6 +9,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -118,6 +120,8 @@ public class OcrService {
         JSONObject responseJson = new JSONObject(jsonResponse);
         JSONArray images = responseJson.getJSONArray("images");
 
+        Pattern pattern = Pattern.compile(".*?대학교");
+
         return IntStream.range(0, images.length())
                 .mapToObj(images::getJSONObject)
                 .flatMap(image -> {
@@ -126,7 +130,14 @@ public class OcrService {
                             .mapToObj(fields::getJSONObject);
                 })
                 .map(field -> field.getString("inferText"))
-                .filter(inferText -> inferText.contains("대학교"))
+                .filter(inferText -> pattern.matcher(inferText).find())
+                .map(inferText -> {
+                    Matcher matcher = pattern.matcher(inferText);
+                    if (matcher.find()) {
+                        return matcher.group();
+                    }
+                    return inferText;
+                })
                 .collect(Collectors.joining(", "));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
@@ -138,6 +138,6 @@ public class OcrService {
                     }
                     return inferText;
                 })
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
@@ -16,7 +16,7 @@ import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.sopt.seonyakServer.global.common.dto.OcrTextResponse;
+import org.sopt.seonyakServer.global.common.dto.OcrUnivResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class OcrService {
     private final OcrConfig ocrConfig;
 
-    public OcrTextResponse ocrText(MultipartFile file) throws IOException {
+    public OcrUnivResponse ocrText(MultipartFile file) throws IOException {
         // OCR 설정파일로부터 URL, Secret Key 가져옴
         String apiUrl = ocrConfig.getApiUrl();
         String apiKey = ocrConfig.getApiKey();
@@ -76,7 +76,7 @@ public class OcrService {
         }
         br.close();
 
-        return OcrTextResponse.of(extractUnivText(response.toString()));
+        return OcrUnivResponse.of(extractUnivText(response.toString()));
     }
 
 

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
@@ -1,0 +1,139 @@
+package org.sopt.seonyakServer.global.common.external.naver;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.sopt.seonyakServer.global.common.dto.OcrTextResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class OcrService {
+    private final OcrConfig ocrConfig;
+
+    public OcrTextResponse ocrText(MultipartFile file) throws IOException {
+        // OCR 설정파일로부터 URL, Secret Key 가져옴
+        String apiUrl = ocrConfig.getApiUrl();
+        String apiKey = ocrConfig.getApiKey();
+
+        // 네이버 OCR API 요청 헤더 설정
+        URL url = new URL(apiUrl);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setUseCaches(false);
+        con.setDoInput(true);
+        con.setDoOutput(true);
+        con.setReadTimeout(30000);
+        con.setRequestMethod("POST");
+        String boundary = "----" + UUID.randomUUID().toString().replaceAll("-", "");
+        con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+        con.setRequestProperty("X-OCR-SECRET", apiKey);
+
+        // 네이버 OCR API 요청 바디 설정
+        JSONObject json = new JSONObject();
+        json.put("version", "V2");
+        json.put("requestId", UUID.randomUUID().toString());
+        json.put("timestamp", System.currentTimeMillis());
+        JSONObject image = new JSONObject();
+        image.put("format", "jpg");
+        image.put("name", "demo");
+        JSONArray images = new JSONArray();
+        images.put(image);
+        json.put("images", images);
+        String postParams = json.toString();
+
+        // 네이버 OCR API 요청 날림
+        con.connect();
+        try (DataOutputStream wr = new DataOutputStream(con.getOutputStream())) {
+            writeMultiPart(wr, postParams, file, boundary);
+            wr.flush();
+        }
+
+        int responseCode = con.getResponseCode();
+        BufferedReader br;
+        if (responseCode == 200) {
+            br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        } else {
+            br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+        }
+        String inputLine;
+        StringBuilder response = new StringBuilder();
+        while ((inputLine = br.readLine()) != null) {
+            response.append(inputLine);
+        }
+        br.close();
+
+        return OcrTextResponse.of(extractUnivText(response.toString()));
+    }
+
+
+    // 네이버 공식문서 대로 OCR 요청 보내는 함수
+    private static void writeMultiPart(OutputStream out, String jsonMessage, MultipartFile file, String boundary)
+            throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("--").append(boundary).append("\r\n");
+        sb.append("Content-Disposition:form-data; name=\"message\"\r\n\r\n");
+        sb.append(jsonMessage);
+        sb.append("\r\n");
+
+        out.write(sb.toString().getBytes("UTF-8"));
+        out.flush();
+
+        if (!file.isEmpty()) {
+            out.write(("--" + boundary + "\r\n").getBytes("UTF-8"));
+            StringBuilder fileString = new StringBuilder();
+            fileString
+                    .append("Content-Disposition:form-data; name=\"file\"; filename=");
+            fileString.append("\"" + file.getOriginalFilename() + "\"\r\n");
+            fileString.append("Content-Type: application/octet-stream\r\n\r\n");
+            out.write(fileString.toString().getBytes("UTF-8"));
+            out.flush();
+
+            try (InputStream fis = file.getInputStream()) {
+                byte[] buffer = new byte[8192];
+                int count;
+                while ((count = fis.read(buffer)) != -1) {
+                    out.write(buffer, 0, count);
+                }
+                out.write("\r\n".getBytes());
+            }
+
+            out.write(("--" + boundary + "--\r\n").getBytes("UTF-8"));
+        }
+        out.flush();
+    }
+
+    // OCR 응답 JSON에서 "대학교"가 포함된 inferText만 추출하는 함수
+    private String extractUnivText(String jsonResponse) {
+        JSONObject responseJson = new JSONObject(jsonResponse);
+        JSONArray images = responseJson.getJSONArray("images");
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < images.length(); i++) {
+            JSONObject image = images.getJSONObject(i);
+            JSONArray fields = image.getJSONArray("fields");
+
+            for (int j = 0; j < fields.length(); j++) {
+                JSONObject field = fields.getJSONObject(j);
+                String inferText = field.getString("inferText");
+
+                if (inferText.contains("대학교")) {
+                    if (result.length() > 0) {
+                        result.append(", ");
+                    }
+                    result.append(inferText);
+                }
+            }
+        }
+        return result.toString();
+    }
+}


### PR DESCRIPTION
# 💡 Issue
- resolved: #8 

# 📸 Screenshot
![image](https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/assets/101867059/362b48d2-5bc9-4234-a767-10f678a22497)


# 📄 Description
* 네이버 클라우드 플랫폼 계정 생성 후 API 키 발급받았습니다.
* 발급받은 API URL, SecretKey 기반으로 API 연동완료했습니다. (노션에 공유 완료)
* 응답받은 JSON을 파싱해서 "대학교"가 포함된 inferText만을 응답해주도록 했습니다.
* 정규표현식을 활용하여 "경희대학교 교무처장"와 같은 텍스트를 "경희대학교"까지만 추출해서 응답하도록 수정했습니다.
* 발급받은 API URL, API Key가 노출되지 않도록 Config파일에서 yml파일을 통해 가져온 값들을 사용하도록 했습니다.
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/6a575bb2654e3ae65a6e934b4c5b7e0d4babb037/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java#L28-L31

# 💬 To Reviewers
* 기본적으로 사진파일에 접근함으로써 발생하는 IOException만을 처리해주었습니다.
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/6a575bb2654e3ae65a6e934b4c5b7e0d4babb037/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java#L20-L23
* "대학교"라는 텍스트가 없는 이미지와 같은 예외 케이스에 대한 테스트를 진행하고 에러를 추가해야될것 같습니다.


# 🔗 Reference
* 네이버 OCR 공식문서
https://api.ncloud-docs.com/docs/ai-application-service-ocr-ocr#api-%EC%98%88%EC%A0%9C