### PR TITLE
[FEAT] #15 - 구글 미트 API 연동

### DIFF
--- a/.github/workflows/DOCKER-CD.yml
+++ b/.github/workflows/DOCKER-CD.yml
@@ -28,6 +28,14 @@ jobs:
           cat ./application.yml
         working-directory: ${{ env.working-directory }}
 
+      - name: credentials.json 생성
+        run: |
+          mkdir -p ./src/main/resources && cd $_
+          touch ./credentials.json
+          echo "${{ secrets.GOOGLE_CREDENTIALS }}" > ./credentials.json
+          cat ./credentials.json
+        working-directory: ${{ env.working-directory }}
+
       - name: 빌드
         run: |
           chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ application.yaml
 application.yml
 credentials.json
 
+### 구글미트 액세스 토큰 ###
 /tokens

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ out/
 application-secret.properties
 application.yaml
 application.yml
+credentials.json
+
+/tokens

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
 }
-
 group = 'org.sopt'
 version = '0.0.1-SNAPSHOT'
 
@@ -21,6 +20,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://maven.google.com' }
 }
 
 dependencies {
@@ -68,16 +68,16 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0' // 쿼리 파라미터 로그 남기기
+
+    // GoogleMeet
+    implementation platform('com.google.cloud:libraries-bom:26.42.0')
+    implementation 'com.google.cloud:google-cloud-meet:0.3.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
 }
 
 ext {
     set('springCloudVersion', "2023.0.2")
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -9,7 +9,7 @@ import org.sopt.seonyakServer.global.auth.MemberAuthentication;
 import org.sopt.seonyakServer.global.auth.jwt.JwtTokenProvider;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberInfoResponse;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberLoginRequest;
-import org.sopt.seonyakServer.global.common.external.client.google.GoogleSocialService;
+import org.sopt.seonyakServer.global.common.external.client.service.GoogleSocialService;
 import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
 import org.springframework.dao.DataIntegrityViolationException;

--- a/src/main/java/org/sopt/seonyakServer/global/auth/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/auth/security/SecurityConfig.java
@@ -24,11 +24,12 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     private static final String[] AUTH_WHITE_LIST = {
+            "/api/v1/**",
             "/api/v1/auth/**",
             "/actuator/health",
             "/v3/api-docs/**",
             "/swagger-ui/**",
-            "/swagger-resources/**"
+            "/swagger-resources/**",
     };
 
     @Bean

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/client/service/GoogleSocialService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/client/service/GoogleSocialService.java
@@ -1,4 +1,4 @@
-package org.sopt.seonyakServer.global.common.external.client.google;
+package org.sopt.seonyakServer.global.common.external.client.service;
 
 import feign.FeignException;
 import lombok.Getter;
@@ -8,7 +8,8 @@ import org.sopt.seonyakServer.domain.member.model.SocialType;
 import org.sopt.seonyakServer.global.common.external.client.dto.GoogleUserInfoResponse;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberInfoResponse;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberLoginRequest;
-import org.sopt.seonyakServer.global.common.external.client.service.SocialService;
+import org.sopt.seonyakServer.global.common.external.client.google.GoogleAccessTokenClient;
+import org.sopt.seonyakServer.global.common.external.client.google.GoogleUserClient;
 import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetConfig.java
@@ -114,14 +114,5 @@ public class GoogleMeetConfig {
             throw new CustomException(ErrorType.GET_GOOGLE_AUTHORIZER_ERROR);
 
         }
-        // Credentials가 null인 경우, 사용자 인증화면 띄줘줘야함
-//        URL authorizationUrl = userAuthorizer.getAuthorizationUrl(USER, "", null);
-//        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-//            Desktop.getDesktop().browse(authorizationUrl.toURI());
-//        } else {
-//            System.out.printf("Open the following URL to authorize access: %s\n", authorizationUrl.toExternalForm());
-//        }
-//        String code = localServerReceiver.waitForCode();
-//        return userAuthorizer.getAndStoreCredentialsFromCode(USER, code, URI.create(callbackUri));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetConfig.java
@@ -1,0 +1,122 @@
+package org.sopt.seonyakServer.global.common.external.googlemeet;
+
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.apps.meet.v2.SpacesServiceSettings;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ClientId;
+import com.google.auth.oauth2.DefaultPKCEProvider;
+import com.google.auth.oauth2.TokenStore;
+import com.google.auth.oauth2.UserAuthorizer;
+import java.awt.Desktop;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GoogleMeetConfig {
+
+    @Value("${google.credentials.file.path}")
+    private String credentialsFilePath;
+
+    @Value("${google.credentials.oauth2.callback.uri}")
+    private String callbackUri;
+
+    @Value("${google.credentials.tokens.directory.path}")
+    private String tokensDirectoryPath;
+
+    @Value("${google.credentials.scopes}")
+    private List<String> scopes;
+
+    private static final String USER = "default";
+
+    @Bean
+    public TokenStore tokenStore() {
+        return new TokenStore() {
+            private Path pathFor(String id) {
+                return Paths.get(".", tokensDirectoryPath, id + ".json");
+            }
+
+            @Override
+            public String load(String id) throws IOException {
+                if (!Files.exists(pathFor(id))) {
+                    return null;
+                }
+                return Files.readString(pathFor(id));
+            }
+
+            @Override
+            public void store(String id, String token) throws IOException {
+                Files.createDirectories(Paths.get(".", tokensDirectoryPath));
+                Files.writeString(pathFor(id), token);
+            }
+
+            @Override
+            public void delete(String id) throws IOException {
+                if (!Files.exists(pathFor(id))) {
+                    return;
+                }
+                Files.delete(pathFor(id));
+            }
+        };
+    }
+
+    @Bean
+    public UserAuthorizer userAuthorizer(TokenStore tokenStore) throws IOException {
+        try (InputStream in = getClass().getResourceAsStream(credentialsFilePath)) {
+            if (in == null) {
+                throw new IOException("Resource not found: " + credentialsFilePath);
+            }
+            ClientId clientId = ClientId.fromStream(in);
+            return UserAuthorizer.newBuilder()
+                    .setClientId(clientId)
+                    .setCallbackUri(URI.create(callbackUri))
+                    .setScopes(scopes)
+                    .setPKCEProvider(new DefaultPKCEProvider() {
+                        @Override
+                        public String getCodeChallenge() {
+                            return super.getCodeChallenge().split("=")[0];
+                        }
+                    })
+                    .setTokenStore(tokenStore)
+                    .build();
+        }
+    }
+
+    @Bean
+    public LocalServerReceiver localServerReceiver() {
+        return new LocalServerReceiver.Builder().setPort(8082).build();
+    }
+
+    @Bean
+    public SpacesServiceSettings spacesServiceSettings(Credentials credentials) throws IOException {
+        return SpacesServiceSettings.newBuilder()
+                .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public Credentials credentials(UserAuthorizer userAuthorizer, LocalServerReceiver localServerReceiver)
+            throws Exception {
+        Credentials credentials = userAuthorizer.getCredentials(USER);
+        if (credentials != null) {
+            return credentials;
+        }
+        URL authorizationUrl = userAuthorizer.getAuthorizationUrl(USER, "", null);
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            Desktop.getDesktop().browse(authorizationUrl.toURI());
+        } else {
+            System.out.printf("Open the following URL to authorize access: %s\n", authorizationUrl.toExternalForm());
+        }
+        String code = localServerReceiver.waitForCode();
+        return userAuthorizer.getAndStoreCredentialsFromCode(USER, code, URI.create(callbackUri));
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetController.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetController.java
@@ -1,0 +1,29 @@
+package org.sopt.seonyakServer.global.common.external.googlemeet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.seonyakServer.global.common.external.googlemeet.dto.GoogleMeetUrlResponse;
+import org.sopt.seonyakServer.global.exception.enums.ErrorType;
+import org.sopt.seonyakServer.global.exception.model.CustomException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/")
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleMeetController {
+    private final GoogleMeetService googleMeetService;
+
+    @PostMapping("/google-meet")
+    public ResponseEntity<GoogleMeetUrlResponse> createSpace() {
+        try {
+            return ResponseEntity.ok(googleMeetService.createMeetingSpace());
+        } catch (Exception e) {
+            log.info(e.getMessage());
+            throw new CustomException(ErrorType.GET_GOOGLE_MEET_URL_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetService.java
@@ -1,0 +1,29 @@
+package org.sopt.seonyakServer.global.common.external.googlemeet;
+
+import com.google.apps.meet.v2.CreateSpaceRequest;
+import com.google.apps.meet.v2.Space;
+import com.google.apps.meet.v2.SpacesServiceClient;
+import com.google.apps.meet.v2.SpacesServiceSettings;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.global.common.external.googlemeet.dto.GoogleMeetUrlResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleMeetService {
+    private final SpacesServiceSettings spacesServiceSettings;
+
+    public GoogleMeetUrlResponse createMeetingSpace() throws Exception {
+        try (SpacesServiceClient spacesServiceClient = SpacesServiceClient.create(spacesServiceSettings)) {
+            CreateSpaceRequest request = CreateSpaceRequest.newBuilder()
+                    .setSpace(Space.newBuilder().build())
+                    .build();
+            Space response = spacesServiceClient.createSpace(request);
+            return GoogleMeetUrlResponse.of(response.getMeetingUri());
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetService.java
@@ -4,7 +4,6 @@ import com.google.apps.meet.v2.CreateSpaceRequest;
 import com.google.apps.meet.v2.Space;
 import com.google.apps.meet.v2.SpacesServiceClient;
 import com.google.apps.meet.v2.SpacesServiceSettings;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.global.common.external.googlemeet.dto.GoogleMeetUrlResponse;
 import org.springframework.stereotype.Service;
@@ -15,15 +14,11 @@ public class GoogleMeetService {
     private final SpacesServiceSettings spacesServiceSettings;
 
     public GoogleMeetUrlResponse createMeetingSpace() throws Exception {
-        try (SpacesServiceClient spacesServiceClient = SpacesServiceClient.create(spacesServiceSettings)) {
-            CreateSpaceRequest request = CreateSpaceRequest.newBuilder()
-                    .setSpace(Space.newBuilder().build())
-                    .build();
-            Space response = spacesServiceClient.createSpace(request);
-            return GoogleMeetUrlResponse.of(response.getMeetingUri());
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw e;
-        }
+        SpacesServiceClient spacesServiceClient = SpacesServiceClient.create(spacesServiceSettings);
+        CreateSpaceRequest request = CreateSpaceRequest.newBuilder()
+                .setSpace(Space.newBuilder().build())
+                .build();
+        Space response = spacesServiceClient.createSpace(request);
+        return GoogleMeetUrlResponse.of(response.getMeetingUri());
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/dto/GoogleMeetUrlResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/dto/GoogleMeetUrlResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.seonyakServer.global.common.external.googlemeet.dto;
+
+public record GoogleMeetUrlResponse(
+        String googleMeet
+) {
+    public static GoogleMeetUrlResponse of(
+            final String googleMeet
+    ) {
+        return new GoogleMeetUrlResponse(googleMeet);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
@@ -2,7 +2,7 @@ package org.sopt.seonyakServer.global.common.external.naver;
 
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.sopt.seonyakServer.global.common.dto.OcrUnivResponse;
+import org.sopt.seonyakServer.global.common.external.naver.dto.OcrUnivResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
@@ -16,7 +16,7 @@ import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.sopt.seonyakServer.global.common.dto.OcrUnivResponse;
+import org.sopt.seonyakServer.global.common.external.naver.dto.OcrUnivResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/dto/OcrUnivResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/dto/OcrUnivResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.seonyakServer.global.common.dto;
+package org.sopt.seonyakServer.global.common.external.naver.dto;
 
 public record OcrUnivResponse(
         String univName

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -49,6 +49,7 @@ public enum ErrorType {
      */
     NOT_FOUND_MEMBER_ERROR(HttpStatus.NOT_FOUND, "40401", "존재하지 않는 회원입니다."),
     NOT_FOUND_REFRESH_TOKEN_ERROR(HttpStatus.NOT_FOUND, "40402", "존재하지 않는 리프레시 토큰입니다."),
+    NOT_FOUND_CREDENTIALS_JSON_ERROR(HttpStatus.NOT_FOUND, "40403", "구글미트 Credentials Json 파일을 찾을 수 없습니다."),
 
     /**
      * 409 CONFLICT
@@ -60,7 +61,8 @@ public enum ErrorType {
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50001", "알 수 없는 서버 에러가 발생했습니다."),
     GET_UPLOAD_PRESIGNED_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50002", "업로드를 위한 Presigned URL 획득에 실패했습니다."),
-    GET_GOOGLE_MEET_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50003", "구글미트 URL 획득에 실패했습니다.");
+    GET_GOOGLE_MEET_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50003", "구글미트 URL 획득에 실패했습니다."),
+    GET_GOOGLE_AUTHORIZER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50004", "구글미트 URL 획득에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -59,7 +59,8 @@ public enum ErrorType {
      * 500 INTERNAL SERVER ERROR
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50001", "알 수 없는 서버 에러가 발생했습니다."),
-    GET_UPLOAD_PRESIGNED_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50002", "업로드를 위한 Presigned URL 획득에 실패했습니다.");
+    GET_UPLOAD_PRESIGNED_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50002", "업로드를 위한 Presigned URL 획득에 실패했습니다."),
+    GET_GOOGLE_MEET_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50003", "구글미트 URL 획득에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
# 💡 Issue
- resolved: #15 

# 📄 Description
* 구글 공식문서를 참고하여 "선약"계정으로 구글미트 회의공간을 만들어주는 API입니다.
* 선배홈에서 선배 사용자가 약속을 수락하면 구글미틔 회의공간을 생성한 뒤, 회의공간 URL을 약속과 매핑해 DB에 저장합니다.


# 💬 To Reviewers
* 구글 미트와 관련된 변수들을 Config파일을 만들어 설정해주었습니다.
* 구글 미트 연동을 위한 인증 설정 또한 Config파일에서 설정해주었기 때문에, Config파일 위주로 살펴보시면 될 것 같습니다!
* 또한 리소스 디렉토리에 선약 계정의 구글 인증정보가 저장되어 있는 credentials.json파일을 만들고 gitignore 파일에 추가했기 때문에, 시크릿 키를 추가해서 CI 과정에서 추가되도록 설정해두었습니다.

# 🔗 Reference
### 구글미트 공식 문서
* https://developers.google.com/meet/api/guides/meeting-spaces?hl=ko#java
* https://cloud.google.com/java/docs/reference/google-cloud-meet/latest/overview