### PR TITLE
[FIX] #26 - JSON 라이브러리 적용

### DIFF
--- a/.github/workflows/DOCKER-CD.yml
+++ b/.github/workflows/DOCKER-CD.yml
@@ -29,11 +29,11 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: credentials.json 생성
-        run: |
-          mkdir -p ./src/main/resources && cd $_
-          touch ./credentials.json
-          echo "${{ secrets.GOOGLE_CREDENTIALS }}" > ./credentials.json
-        working-directory: ${{ env.working-directory }}
+        id: create-json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "./src/main/resources/credentials.json"
+          json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
       - name: 빌드
         run: |


### PR DESCRIPTION
# 💡 Issue
- resolved: #26 

# 📄 Description
* CD과정에서 시크릿키에 등록된 JSON 파일을 생성할 때, 라이브러리를 적용했습니다.

# 💬 To Reviewers
	- 시크릿키에 JSON 파일을 등록은 최대한 지양하고, 필요한 경우 적절한 방식을 적용해야할 것 같습니다!

# 🔗 Reference
* https://velog.io/@hnnynh/Github-Actions%EC%97%90%EC%84%9C-secrets.json-%EC%83%9D%EC%84%B1%ED%95%98%EA%B8%B0
* https://harsh-step-7dd.notion.site/FCM-json-EC2-957941189e044b4c9844123f2c2d2c37