### PR TITLE
[FEAT] #30 - S3로부터 구글 설정파일 생성

### DIFF
--- a/.github/workflows/DOCKER-CD.yml
+++ b/.github/workflows/DOCKER-CD.yml
@@ -28,12 +28,18 @@ jobs:
           cat ./application.yml
         working-directory: ${{ env.working-directory }}
 
-      - name: credentials.json 생성
-        id: create-json
-        uses: jsdaniell/create-json@1.1.2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          name: "credentials.json"
-          json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: credentials.json 생성
+        run: |
+          cd ./SEONYAK-SERVER/src/main/resources
+          aws s3 cp --region ap-northeast-2 s3://${{ secrets.S3_BUCKET_NAME }}/json/credentials.json .
+        shell: bash
 
       - name: 빌드
         run: |


### PR DESCRIPTION
# 💡 Issue
- resolved: #30 

# 📄 Description
* 선약 계정에 S3 버킷 생성
* S3를 외부에서 접근할 수 있도록 권한 설정
* 깃허브 액션 시크릿키에 엑세스키 설정
* CD 단계에서 AWS 권한 설정 후 S3 버킷에 생성해둔 JSON 파일을 카피해오도록 수정