### PR TITLE
[FEAT] #55 - 네이버 명함 OCR API 연동

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/global/auth/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/auth/security/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITE_LIST = {
             "/api/v1/**",
+            "/api/v1/ocr/**",
             "/api/v1/auth/**",
             "/actuator/health",
             "/v3/api-docs/**",

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrConfig.java
@@ -8,10 +8,16 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 public class OcrConfig {
 
-    @Value("${naver.ocr.api.url}")
-    private String apiUrl;
+    @Value("${naver.ocr.api.univ-url}")
+    private String univUrl;
 
-    @Value("${naver.ocr.api.key}")
-    private String apiKey;
-    
+    @Value("${naver.ocr.api.univ-key}")
+    private String univUrlKey;
+
+    @Value("${naver.ocr.api.business-url}")
+    private String businessUrl;
+
+    @Value("${naver.ocr.api.business-key}")
+    private String businessKey;
+
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrController.java
@@ -2,6 +2,7 @@ package org.sopt.seonyakServer.global.common.external.naver;
 
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.global.common.external.naver.dto.OcrBusinessResponse;
 import org.sopt.seonyakServer.global.common.external.naver.dto.OcrUnivResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,7 +19,14 @@ public class OcrController {
     private final OcrService ocrService;
 
     @PostMapping("/univ")
-    public ResponseEntity<OcrUnivResponse> ocrText(@RequestParam("imageFile") MultipartFile file) throws IOException {
-        return ResponseEntity.ok(ocrService.ocrText(file));
+    public ResponseEntity<OcrUnivResponse> ocrUniv(@RequestParam("imageFile") MultipartFile file)
+            throws IOException {
+        return ResponseEntity.ok(ocrService.ocrUniv(file));
+    }
+
+    @PostMapping("/business-card")
+    public ResponseEntity<OcrBusinessResponse> ocrBusiness(@RequestParam("imageFile") MultipartFile file)
+            throws IOException {
+        return ResponseEntity.ok(ocrService.ocrBusiness(file));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/OcrService.java
@@ -46,6 +46,9 @@ public class OcrService {
         //회사명, 휴대전화번호 JSON 응답에서 파싱
         String company = extractTextByKey(requestNaverOcr(apiUrl, apiKey, file), "company");
         String phoneNumber = extractTextByKey(requestNaverOcr(apiUrl, apiKey, file), "mobile");
+        String cleanedNumber = phoneNumber.replaceAll("[^\\d]", "");
+        String lastEightNumber =
+                cleanedNumber.length() > 8 ? cleanedNumber.substring(cleanedNumber.length() - 8) : cleanedNumber;
         return OcrBusinessResponse.of(company, "010" + lastEightNumber);
     }
 

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/naver/dto/OcrBusinessResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/naver/dto/OcrBusinessResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.seonyakServer.global.common.external.naver.dto;
+
+public record OcrBusinessResponse(
+        String company,
+        String phoneNumber
+) {
+    public static OcrBusinessResponse of(String company, String phoneNumber) {
+        return new OcrBusinessResponse(company, phoneNumber);
+    }
+}


### PR DESCRIPTION
# 💡 Issue
- resolved: #55 

# 📄 Description
* 네이버 명함 API를 신청한뒤, 명함 사진을 받으면 회사명, 전화번호를 응답해주는 API입니다.
* 기존 대학명 API 요청부가 동일해서 함수로 분리해주었습니다.
* +8212345678, 01012345678, 010-1234-5678 등 여러 형식의 전화번호들을 정규표현식으로 11자의 숫자만 반환하도록 했습니다.

# 💬 To Reviewers
- 추후 presigned url API가 완성된다면 사진을 multipart 방식으로 받지 않을 수도 있습니다.

# 🔗 Reference
* 네이버 명함 OCR 공식 문서
https://api.ncloud-docs.com/docs/ai-application-service-ocr-ocrdocumentocr