### PR TITLE
[FEAT] #61 - 온보딩 닉네임 유효성 검증 API 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.LoginSuccessResponse;
 import org.sopt.seonyakServer.domain.member.dto.NicknameRequest;
 import org.sopt.seonyakServer.domain.member.service.MemberService;
-import org.sopt.seonyakServer.global.common.dto.ResponseDto;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberLoginRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,11 +29,11 @@ public class MemberController {
     }
 
     @PostMapping("/nickname")
-    public ResponseDto<?> validNickname(
+    public ResponseEntity<Void> validNickname(
             @RequestBody final NicknameRequest nicknameRequest
     ) {
         memberService.validNickname(nicknameRequest);
 
-        return ResponseDto.success(null);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
@@ -3,7 +3,9 @@ package org.sopt.seonyakServer.domain.member.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.LoginSuccessResponse;
+import org.sopt.seonyakServer.domain.member.dto.NicknameRequest;
 import org.sopt.seonyakServer.domain.member.service.MemberService;
+import org.sopt.seonyakServer.global.common.dto.ResponseDto;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberLoginRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,16 +16,25 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/login")
+    @PostMapping("/auth/login")
     public ResponseEntity<LoginSuccessResponse> login(
             @RequestParam final String authorizationCode,
             @RequestBody @Valid final MemberLoginRequest loginRequest
     ) {
         return ResponseEntity.ok(memberService.create(authorizationCode, loginRequest));
+    }
+
+    @PostMapping("/nickname")
+    public ResponseDto<?> validNickname(
+            @RequestBody final NicknameRequest nicknameRequest
+    ) {
+        memberService.validNickname(nicknameRequest);
+
+        return ResponseDto.success(null);
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/NicknameRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/NicknameRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.seonyakServer.domain.member.dto;
+
+public record NicknameRequest(
+        String nickname
+) {
+    public static NicknameRequest of(final String nickname) {
+        return new NicknameRequest(nickname);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -1,7 +1,5 @@
 package org.sopt.seonyakServer.domain.member.service;
 
-import static org.sopt.seonyakServer.global.common.RegularExpression.NICKNAME_PATTERN;
-
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.LoginSuccessResponse;
 import org.sopt.seonyakServer.domain.member.dto.NicknameRequest;
@@ -26,6 +24,8 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleSocialService googleSocialService;
     private final MemberManagementService memberManagementService;
+
+    public static final String NICKNAME_PATTERN = "^[a-zA-Z0-9가-힣]{2,8}$";
 
     // JWT Access Token 생성
     public LoginSuccessResponse create(

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -1,7 +1,10 @@
 package org.sopt.seonyakServer.domain.member.service;
 
+import static org.sopt.seonyakServer.global.common.RegularExpression.NICKNAME_PATTERN;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.LoginSuccessResponse;
+import org.sopt.seonyakServer.domain.member.dto.NicknameRequest;
 import org.sopt.seonyakServer.domain.member.model.Member;
 import org.sopt.seonyakServer.domain.member.model.SocialType;
 import org.sopt.seonyakServer.domain.member.repository.MemberRepository;
@@ -86,5 +89,16 @@ public class MemberService {
         MemberAuthentication memberAuthentication = new MemberAuthentication(id, null, null);
 
         return LoginSuccessResponse.of(jwtTokenProvider.issueAccessToken(memberAuthentication));
+    }
+
+    // 닉네임 유효성 검증
+    public void validNickname(final NicknameRequest nicknameRequest) {
+        if (!nicknameRequest.nickname().matches(NICKNAME_PATTERN)) { // 형식 체크
+            throw new CustomException(ErrorType.INVALID_NICKNAME_ERROR);
+        }
+
+        if (memberRepository.existsByNickname(nicknameRequest.nickname())) { // 중복 체크
+            throw new CustomException(ErrorType.NICKNAME_DUP_ERROR);
+        }
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/common/RegularExpression.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/RegularExpression.java
@@ -1,6 +1,0 @@
-package org.sopt.seonyakServer.global.common;
-
-public class RegularExpression {
-
-    public static final String NICKNAME_PATTERN = "^[a-zA-Z0-9가-힣]{2,8}$";
-}

--- a/src/main/java/org/sopt/seonyakServer/global/common/RegularExpression.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/RegularExpression.java
@@ -1,0 +1,6 @@
+package org.sopt.seonyakServer.global.common;
+
+public class RegularExpression {
+
+    public static final String NICKNAME_PATTERN = "^[a-zA-Z0-9가-힣]{2,8}$";
+}

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
     INVALID_CODE_HEADER_ERROR(HttpStatus.BAD_REQUEST, "40007", "code 헤더값의 형식이 잘못되었습니다."),
     INVALID_SOCIAL_TYPE_ERROR(HttpStatus.BAD_REQUEST, "40008", "유효하지 않은 Social Type입니다."),
     BEARER_LOST_ERROR(HttpStatus.BAD_REQUEST, "40009", "요청한 토큰이 Bearer 토큰이 아닙니다."),
+    INVALID_NICKNAME_ERROR(HttpStatus.BAD_REQUEST, "40010", "닉네임이 조건을 만족하지 않습니다."),
     MAP_TO_JSON_ERROR(HttpStatus.BAD_REQUEST, "40016", "Map을 JSON 문자열로 변환하는 중 오류가 발생했습니다."),
     JSON_TO_MAP_ERROR(HttpStatus.BAD_REQUEST, "40017", "JSON 문자열을 Map으로 변환하는 중 오류가 발생했습니다."),
 


### PR DESCRIPTION
# 💡 Issue
- resolved: #61 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->

- 닉네임 유효성 검증 성공

<img width="934" alt="image" src="https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/assets/81475587/48b50818-f169-4c1f-8869-56c91a9e2017">

- 8자 초과

<img width="937" alt="image" src="https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/assets/81475587/13b7918c-8422-4aaa-8344-4a17fcc9e52c">

- 특수문자

<img width="930" alt="image" src="https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/assets/81475587/72162474-65aa-4d48-9cb0-13f143682b03">

- 중복 체크

<img width="925" alt="image" src="https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/assets/81475587/30a530b9-74b8-4169-95ce-cd80b5ae9ce6">

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 정규식을 사용해 닉네임 형식을 체크했습니다.
- Spring Data JPA에서 제공하는 `existsBy~` 메서드를 사용해 DB에 하나라도 중복인 레코드가 있으면 에러를 띄우게 처리했습니다.