### PR TITLE
[FEAT] #59 - 사진 업로드를 위한 Presigned URL 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 
     // S3
     implementation 'software.amazon.awssdk:s3:2.17.0'
+    implementation 'com.h2database:h2'
 }
 
 ext {

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetConfig.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/googlemeet/GoogleMeetConfig.java
@@ -19,10 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -43,25 +40,6 @@ public class GoogleMeetConfig {
 
     @Value("${aws-property.s3-bucket-name}")
     private String bucketName;
-
-    @Value("${aws-property.access-key}")
-    private String accessKeyId;
-
-    @Value("${aws-property.secret-key}")
-    private String secretAccessKey;
-
-    @Value("${aws-property.aws-region}")
-    private String awsRegion;
-
-    @Bean
-    public S3Client s3Client() {
-        return S3Client.builder()
-                .region(Region.of(awsRegion))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKeyId, secretAccessKey)
-                ))
-                .build();
-    }
 
     private static final String USER = "default";
 

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Controller.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Controller.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class S3Controller {
     private final S3Service s3Service;

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Controller.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Controller.java
@@ -1,0 +1,21 @@
+package org.sopt.seonyakServer.global.common.external.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.global.common.external.s3.dto.PreSignedUrlResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/")
+@RequiredArgsConstructor
+public class S3Controller {
+    private final S3Service s3Service;
+
+    @GetMapping("/image")
+    public ResponseEntity<PreSignedUrlResponse> getPreSignedUrl() {
+        return ResponseEntity.ok(s3Service.getUploadPreSignedUrl());
+    }
+
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Service.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Service.java
@@ -24,7 +24,7 @@ public class S3Service {
 
     // PreSigned URL 만료시간 60분
     private static final Long PRE_SIGNED_URL_EXPIRE_MINUTE = 60L;
-    private final static String imagePath = "/profiles";
+    private final static String imagePath = "profiles/";
 
     public PreSignedUrlResponse getUploadPreSignedUrl() {
         // UUID 파일명 생성

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Service.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Service.java
@@ -1,0 +1,52 @@
+package org.sopt.seonyakServer.global.common.external.s3;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.global.common.external.s3.dto.PreSignedUrlResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${aws-property.s3-bucket-name}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    // PreSigned URL 만료시간 60분
+    private static final Long PRE_SIGNED_URL_EXPIRE_MINUTE = 60L;
+    private final static String imagePath = "/profiles";
+
+    public PreSignedUrlResponse getUploadPreSignedUrl() {
+        // UUID 파일명 생성
+        String uuidFileName = UUID.randomUUID().toString() + ".jpg";
+        // 경로 + 파일 이름
+        String key = imagePath + uuidFileName;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        // S3에서 업로드는 PUT 요청
+        PutObjectPresignRequest preSignedUrlRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(PRE_SIGNED_URL_EXPIRE_MINUTE))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        // Persigned URL 생성
+        URL url = s3Presigner.presignPutObject(preSignedUrlRequest).url();
+
+        return PreSignedUrlResponse.of(uuidFileName, url.toString());
+    }
+
+}

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/s3/dto/PreSignedUrlResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/s3/dto/PreSignedUrlResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.seonyakServer.global.common.external.s3.dto;
+
+public record PreSignedUrlResponse(
+        String fileName,
+        String url
+) {
+    public static PreSignedUrlResponse of(String fileName, String url) {
+        return new PreSignedUrlResponse(fileName, url);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/global/config/S3Config.java
+++ b/src/main/java/org/sopt/seonyakServer/global/config/S3Config.java
@@ -7,10 +7,11 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
-    
+
     @Value("${aws-property.access-key}")
     private String accessKeyId;
 
@@ -23,6 +24,16 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
+                .region(Region.of(awsRegion))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+                ))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner getS3Presigner() {
+        return S3Presigner.builder()
                 .region(Region.of(awsRegion))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(accessKeyId, secretAccessKey)

--- a/src/main/java/org/sopt/seonyakServer/global/config/S3Config.java
+++ b/src/main/java/org/sopt/seonyakServer/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package org.sopt.seonyakServer.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    
+    @Value("${aws-property.access-key}")
+    private String accessKeyId;
+
+    @Value("${aws-property.secret-key}")
+    private String secretAccessKey;
+
+    @Value("${aws-property.aws-region}")
+    private String awsRegion;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(awsRegion))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+                ))
+                .build();
+    }
+}

--- a/src/test/java/org/sopt/seonyakServer/global/common/external/s3/S3ServiceIntegrationTest.java
+++ b/src/test/java/org/sopt/seonyakServer/global/common/external/s3/S3ServiceIntegrationTest.java
@@ -1,0 +1,67 @@
+package org.sopt.seonyakServer.global.common.external.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.sopt.seonyakServer.global.common.external.s3.dto.PreSignedUrlResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@ActiveProfiles("test")
+class S3ServiceIntegrationTest {
+
+    @Autowired
+    private S3Service s3Service;
+
+    @Test
+    void testGetUploadPreSignedUrl() throws Exception {
+        // Pre-Signed URL 생성
+        PreSignedUrlResponse response = s3Service.getUploadPreSignedUrl();
+
+        // Assertions: Pre-Signed URL이 유효한지 확인
+        assertThat(response).isNotNull();
+        assertThat(response.fileName()).isNotEmpty();
+        assertThat(response.url()).isNotEmpty();
+
+        // 이미지 파일 읽기
+        File file = new File("src/test/resources/경희대학교_재학증명서.pdf");
+        byte[] imageData;
+        try (InputStream inputStream = new FileInputStream(file)) {
+            imageData = inputStream.readAllBytes();
+        }
+
+        // Pre-Signed URL로 PUT 요청 보내기
+        URL url = new URL(response.url());
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setDoOutput(true);
+        connection.setRequestMethod("PUT");
+        connection.setRequestProperty("Content-Type", "application/pdf");
+        connection.setRequestProperty("Content-Length", String.valueOf(imageData.length));
+
+        // 이미지 데이터 전송
+        try (InputStream inputStream = new ByteArrayInputStream(imageData)) {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                connection.getOutputStream().write(buffer, 0, bytesRead);
+            }
+        }
+
+        int responseCode = connection.getResponseCode();
+        connection.disconnect();
+
+        // Assertions: HTTP 응답 코드가 200 (성공)인지 확인
+        assertThat(responseCode).isEqualTo(200);
+    }
+}


### PR DESCRIPTION
# 💡 Issue
- resolved: #59 

# 📄 Description
* 구글밋 설정파일에 위치해있던 S3 Client 빈을 S3 설정파일로 분리해주었습니다.
* 사진 업로드를 위한 PresignedURL 반환을 구현했습니다.
* S3에 대한 권한없이 사진을 업로드할 수 있는 PresignedURL과 UUID를 기반으로 만들어진 파일명을 반환해줍니다. 
* 파일명은 버킷상에서 사진의 키값이 되어서, 추후 해당값을 바탕으로 실제 S3의 이미지 URL을 알 수 있습니다.
* 생성된 PresignedURL을 통해 실제로 S3 버킷에 이미지를 올려보는 통합 테스트 코드를 작성했습니다. 
* 테스트 시, test/resources에 원하는 이미지를 위치시켜놓고 테스트해보시면 됩니다.

# 🔗 Reference
![image](https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/assets/101867059/46221f4b-a779-4b24-a804-13a939eda74c)

* https://velog.io/@penrose_15/Spring-Boot%EC%97%90%EC%84%9C-S3-Presigned-URL-%EC%83%9D%EC%84%B1-%EB%B0%A9%EB%B2%95