### PR TITLE
[FEAT] #72 - 계열, 직무로 필터링하여 선배 조회 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java
@@ -1,6 +1,8 @@
 package org.sopt.seonyakServer.domain.senior.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
 import org.sopt.seonyakServer.domain.senior.model.PreferredTimeList;
 import org.sopt.seonyakServer.domain.senior.service.SeniorService;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,5 +35,13 @@ public class SeniorController {
             @PathVariable final Long seniorId
     ) {
         return ResponseEntity.ok(seniorService.getSeniorPreferredTime(seniorId));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<SeniorListResponse>> searchFieldPosition(
+            @RequestParam(required = false) final List<String> field,
+            @RequestParam(required = false) final List<String> position
+    ) {
+        return ResponseEntity.ok(seniorService.searchSeniorFieldPosition(field, position));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorListResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorListResponse.java
@@ -1,0 +1,37 @@
+package org.sopt.seonyakServer.domain.senior.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+// QueryDsl이 Record 클래스 인식을 못해서 사용하지 않음
+public class SeniorListResponse {
+    private Long seniorId;
+    private String nickname;
+    private String company;
+    private String position;
+    private String detailPosition;
+    private String field;
+    private String level;
+
+    public static SeniorListResponse of(
+            final Long seniorId,
+            final String nickname,
+            final String company,
+            final String position,
+            final String detailPosition,
+            final String field,
+            final String level) {
+        return new SeniorListResponse(
+                seniorId,
+                nickname,
+                company,
+                position,
+                detailPosition,
+                field,
+                level);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/repository/SeniorRepository.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/repository/SeniorRepository.java
@@ -6,12 +6,12 @@ import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SeniorRepository extends JpaRepository<Senior, Long> {
+public interface SeniorRepository extends JpaRepository<Senior, Long>, SeniorRepositoryCustom {
 
     Optional<Senior> findSeniorById(Long id);
 
     Optional<Senior> findSeniorByMemberId(Long id);
-    
+
     default Senior findSeniorByIdOrThrow(Long id) {
         return findSeniorById(id)
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_MEMBER_ERROR));

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/repository/SeniorRepositoryCustom.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/repository/SeniorRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.sopt.seonyakServer.domain.senior.repository;
+
+import java.util.List;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
+
+public interface SeniorRepositoryCustom {
+    List<SeniorListResponse> searchSeniorFieldPosition(List<String> fields, List<String> positions);
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/repository/SeniorRepositoryImpl.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/repository/SeniorRepositoryImpl.java
@@ -1,0 +1,62 @@
+package org.sopt.seonyakServer.domain.senior.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
+import org.sopt.seonyakServer.domain.senior.model.QSenior;
+
+public class SeniorRepositoryImpl implements SeniorRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private final QSenior senior = QSenior.senior;
+
+    public SeniorRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<SeniorListResponse> searchSeniorFieldPosition(List<String> fields, List<String> positions) {
+        BooleanExpression fieldCondition = createFieldCondition(senior, fields);
+        BooleanExpression positionCondition = createPositionCondition(senior, positions);
+        return queryFactory
+                .select(Projections.fields(SeniorListResponse.class,
+                        senior.id.as("seniorId"),
+                        senior.company,
+                        senior.position,
+                        senior.detailPosition,
+                        senior.member.nickname,
+                        senior.member.field,
+                        senior.level))
+                .from(senior)
+                .where(fieldCondition, positionCondition)
+                .orderBy(senior.createdAt.asc())
+                .fetch();
+    }
+
+    private BooleanExpression createFieldCondition(QSenior senior, List<String> fields) {
+        // 계열 검색 키워드가 없는 경우
+        if (fields == null || fields.isEmpty()) {
+            return null;
+        }
+        // BooleanExpression을 이용하여 or로 엮음
+        BooleanExpression condition = senior.member.field.eq(fields.get(0));
+        for (String field : fields.subList(1, fields.size())) {
+            condition = condition.or(senior.member.field.eq(field));
+        }
+        return condition;
+    }
+
+    private BooleanExpression createPositionCondition(QSenior senior, List<String> positions) {
+        if (positions == null || positions.isEmpty()) {
+            return null;
+        }
+
+        BooleanExpression condition = senior.position.eq(positions.get(0));
+        for (String position : positions.subList(1, positions.size())) {
+            condition = condition.or(senior.position.eq(position));
+        }
+        return condition;
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -2,7 +2,6 @@ package org.sopt.seonyakServer.domain.senior.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.seonyakServer.domain.member.repository.MemberRepository;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
 import org.sopt.seonyakServer.domain.senior.model.PreferredTimeList;
@@ -20,7 +19,6 @@ public class SeniorService {
 
     private final SeniorRepository seniorRepository;
     private final PrincipalHandler principalHandler;
-    private final MemberRepository memberRepository;
 
     @Transactional
     public void patchSeniorProfile(SeniorProfileRequest seniorProfileRequest) {

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -41,7 +41,7 @@ public class SeniorService {
         return senior.getPreferredTimeList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<SeniorListResponse> searchSeniorFieldPosition(List<String> field, List<String> position) {
         return seniorRepository.searchSeniorFieldPosition(field, position);
     }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -1,6 +1,9 @@
 package org.sopt.seonyakServer.domain.senior.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.domain.member.repository.MemberRepository;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
 import org.sopt.seonyakServer.domain.senior.model.PreferredTimeList;
 import org.sopt.seonyakServer.domain.senior.model.Senior;
@@ -13,12 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class SeniorService {
 
     private final SeniorRepository seniorRepository;
     private final PrincipalHandler principalHandler;
+    private final MemberRepository memberRepository;
 
+    @Transactional
     public void patchSeniorProfile(SeniorProfileRequest seniorProfileRequest) {
         Senior senior = seniorRepository.findSeniorByMemberId(principalHandler.getUserIdFromPrincipal())
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_SENIOR_BY_MEMBER));
@@ -33,8 +37,14 @@ public class SeniorService {
         seniorRepository.save(senior);
     }
 
+    @Transactional(readOnly = true)
     public PreferredTimeList getSeniorPreferredTime(Long seniorId) {
         Senior senior = seniorRepository.findSeniorByIdOrThrow(seniorId);
         return senior.getPreferredTimeList();
+    }
+
+    @Transactional
+    public List<SeniorListResponse> searchSeniorFieldPosition(List<String> field, List<String> position) {
+        return seniorRepository.searchSeniorFieldPosition(field, position);
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #72 

# 📄 Description
* QueryDsl을 이용하여 선배의 직무, 계열로 필터링한 후 검색 결과를 내려주는 API입니다.
* 같은 필드의 경우 (Ex. 직무1, 직무2) OR절이 적용됩니다.
* 다른 필드의 경우 (Ex. 직무1, 계열2) AND절이 적용됩니다.
* 필터링을 전혀 적용하지 않은 경우, 선약 서비스의 등록된 모든 선배의 정보를 내려줍니다.

* 필터링을 적용하지 않는 경우를 고려하여 (required = false) 옵션을 붙혀주었습니다.
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/28399844f51073e8cb8b58db1181a2c3875ae4f3/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java#L40-L46

# 🔗 Reference
* https://velog.io/@guns95/QueryDsl-Where-%EB%8B%A4%EC%A4%91-%EC%A1%B0%EA%B1%B4