### PR TITLE
[FEAT] #82 - 회원가입 API 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package org.sopt.seonyakServer.domain.member.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.LoginSuccessResponse;
+import org.sopt.seonyakServer.domain.member.dto.MemberJoinRequest;
+import org.sopt.seonyakServer.domain.member.dto.MemberJoinResponse;
 import org.sopt.seonyakServer.domain.member.dto.NicknameRequest;
 import org.sopt.seonyakServer.domain.member.dto.SendCodeRequest;
 import org.sopt.seonyakServer.domain.member.dto.VerifyCodeRequest;
@@ -10,6 +12,7 @@ import org.sopt.seonyakServer.domain.member.service.MemberService;
 import org.sopt.seonyakServer.domain.member.service.MessageService;
 import org.sopt.seonyakServer.global.common.external.client.dto.MemberLoginRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +33,13 @@ public class MemberController {
             @RequestBody @Valid final MemberLoginRequest loginRequest
     ) {
         return ResponseEntity.ok(memberService.create(authorizationCode, loginRequest));
+    }
+
+    @PatchMapping("/auth/join")
+    public ResponseEntity<MemberJoinResponse> join(
+            @RequestBody final MemberJoinRequest memberJoinRequest
+    ) {
+        return ResponseEntity.ok(memberService.patchMemberJoin(memberJoinRequest));
     }
 
     @PostMapping("/nickname")

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
@@ -1,0 +1,20 @@
+package org.sopt.seonyakServer.domain.member.dto;
+
+import java.util.List;
+
+public record MemberJoinRequest(
+        String role,
+        Boolean isSubscribed,
+        String nickname,
+        String image,
+        String phoneNumber,
+        String univName,
+        String field,
+        List<String> departmentList,
+        String businessCard,
+        String company,
+        String position,
+        String detailPosition,
+        String level
+) {
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.seonyakServer.domain.member.dto;
+
+public record MemberJoinResponse(
+        String role
+) {
+    public static MemberJoinResponse of(final String role) {
+        return new MemberJoinResponse(role);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
@@ -11,10 +11,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.sopt.seonyakServer.domain.senior.model.Senior;
 import org.sopt.seonyakServer.global.common.model.BaseTimeEntity;
 
@@ -57,8 +60,9 @@ public class Member extends BaseTimeEntity {
     @Column(name = "field")
     private String field;
 
-    @Column(name = "department")
-    private String department;
+    @Column(name = "departmentList", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> departmentList;
 
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Senior senior;
@@ -84,5 +88,37 @@ public class Member extends BaseTimeEntity {
                 .socialId(socialId)
                 .email(email)
                 .build();
+    }
+
+    public void updateMember(
+            Boolean isSubscribed,
+            String nickname,
+            String image,
+            String phoneNumber,
+            String univName,
+            String field,
+            List<String> department
+    ) {
+        if (isSubscribed != null) {
+            this.isSubscribed = isSubscribed;
+        }
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (image != null) {
+            this.image = image;
+        }
+        if (phoneNumber != null) {
+            this.phoneNumber = phoneNumber;
+        }
+        if (univName != null) {
+            this.univName = univName;
+        }
+        if (field != null) {
+            this.field = field;
+        }
+        if (department != null) {
+            this.departmentList = department;
+        }
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -113,8 +113,6 @@ public class MemberService {
     public MemberJoinResponse patchMemberJoin(MemberJoinRequest memberJoinRequest) {
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
 
-        System.out.println("Department List: " + memberJoinRequest.departmentList()); // 로그 추가
-
         member.updateMember(
                 memberJoinRequest.isSubscribed(),
                 memberJoinRequest.nickname(),

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -2,6 +2,8 @@ package org.sopt.seonyakServer.domain.senior.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.domain.member.dto.MemberJoinRequest;
+import org.sopt.seonyakServer.domain.member.model.Member;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
 import org.sopt.seonyakServer.domain.senior.model.PreferredTimeList;
@@ -19,6 +21,23 @@ public class SeniorService {
 
     private final SeniorRepository seniorRepository;
     private final PrincipalHandler principalHandler;
+
+    @Transactional
+    public String createSenior(final MemberJoinRequest memberJoinRequest, Member member) {
+
+        Senior senior = Senior.createSenior(
+                member,
+                memberJoinRequest.businessCard(),
+                memberJoinRequest.detailPosition(),
+                memberJoinRequest.company(),
+                memberJoinRequest.position(),
+                memberJoinRequest.level()
+        );
+
+        seniorRepository.save(senior);
+
+        return memberJoinRequest.role();
+    }
 
     @Transactional
     public void patchSeniorProfile(SeniorProfileRequest seniorProfileRequest) {


### PR DESCRIPTION
# 💡 Issue
- resolved: #82 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
- 후배 회원가입

<img width="394" alt="image" src="https://github.com/user-attachments/assets/2aeed668-f19f-441c-8d5c-a081fe080669">

- 선배 회원가입

<img width="488" alt="image" src="https://github.com/user-attachments/assets/7de262dd-35b7-4048-937d-a2af42109d70">


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 회원가입 로직을 구현했습니다.
- 선배 엔티티가 생성되었는지 여부에 따라 분기 처리하여 role을 반환합니다.