### PR TITLE
[FEAT] #84 - 구글 미트 회의실 링크 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/controller/AppointmentController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/controller/AppointmentController.java
@@ -3,8 +3,11 @@ package org.sopt.seonyakServer.domain.appointment.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentRequest;
+import org.sopt.seonyakServer.domain.appointment.dto.GoogleMeetLinkRequest;
+import org.sopt.seonyakServer.domain.appointment.dto.GoogleMeetLinkResponse;
 import org.sopt.seonyakServer.domain.appointment.service.AppointmentService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,16 +15,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/appoinment")
+@RequestMapping("/api/v1")
 public class AppointmentController {
 
     private final AppointmentService appointmentService;
 
-    @PostMapping("")
+    @PostMapping("/appoinment")
     public ResponseEntity<Void> postAppointment(
             @RequestBody final AppointmentRequest appointmentRequest
     ) {
         appointmentService.postAppointment(appointmentRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/google-meet")
+    public ResponseEntity<GoogleMeetLinkResponse> getGoogleMeetLink(
+            @RequestBody final GoogleMeetLinkRequest googleMeetLinkRequest
+    ) {
+        return ResponseEntity.ok(appointmentService.getGoogleMeetLink(googleMeetLinkRequest));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/GoogleMeetLinkRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/GoogleMeetLinkRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.seonyakServer.domain.appointment.dto;
+
+public record GoogleMeetLinkRequest(
+        Long appointmentId
+) {
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/GoogleMeetLinkResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/GoogleMeetLinkResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.seonyakServer.domain.appointment.dto;
+
+public record GoogleMeetLinkResponse(
+        String googleMeetLink
+) {
+    public static GoogleMeetLinkResponse of(final String googleMeetLink) {
+        return new GoogleMeetLinkResponse(googleMeetLink);
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/repository/AppointmentRepository.java
@@ -2,6 +2,23 @@ package org.sopt.seonyakServer.domain.appointment.repository;
 
 import org.sopt.seonyakServer.domain.appointment.model.Appointment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
+
+    @Query("SELECT a.googleMeetLink "
+            + "FROM Appointment a "
+            + "WHERE a.id = :appointmentId")
+    String findGoogleMeetLinkById(@Param("appointmentId") Long appointmentId);
+
+    @Query("SELECT a.member.id "
+            + "FROM Appointment a "
+            + "WHERE a.id = :appointmentId")
+    Long findMemberIdById(@Param("appointmentId") Long appointmentId);
+
+    @Query("SELECT a.senior.id "
+            + "FROM Appointment a "
+            + "WHERE a.id = :appointmentId")
+    Long findSeniorIdById(@Param("appointmentId") Long appointmentId);
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -2,6 +2,8 @@ package org.sopt.seonyakServer.domain.appointment.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentRequest;
+import org.sopt.seonyakServer.domain.appointment.dto.GoogleMeetLinkRequest;
+import org.sopt.seonyakServer.domain.appointment.dto.GoogleMeetLinkResponse;
 import org.sopt.seonyakServer.domain.appointment.model.Appointment;
 import org.sopt.seonyakServer.domain.appointment.model.AppointmentStatus;
 import org.sopt.seonyakServer.domain.appointment.repository.AppointmentRepository;
@@ -40,5 +42,24 @@ public class AppointmentService {
                 appointmentRequest.personalTopic()
         );
         appointmentRepository.save(appointment);
+    }
+
+    @Transactional(readOnly = true)
+    public GoogleMeetLinkResponse getGoogleMeetLink(GoogleMeetLinkRequest googleMeetLinkRequest) {
+        Long userId = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal()).getId();
+        Long memberId = appointmentRepository.findMemberIdById(googleMeetLinkRequest.appointmentId());
+        Long seniorId = appointmentRepository.findSeniorIdById(googleMeetLinkRequest.appointmentId());
+
+        if (!userId.equals(memberId) && !userId.equals(seniorId)) {
+            throw new CustomException(ErrorType.NOT_MEMBERS_APPOINTMENT_ERROR);
+        }
+
+        String googleMeetLink = appointmentRepository.findGoogleMeetLinkById(googleMeetLinkRequest.appointmentId());
+
+        if (googleMeetLink == null || googleMeetLink.isEmpty()) {
+            throw new CustomException(ErrorType.NOT_FOUND_GOOGLE_MEET_LINK_ERROR);
+        }
+
+        return GoogleMeetLinkResponse.of(googleMeetLink);
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/auth/PrincipalHandler.java
+++ b/src/main/java/org/sopt/seonyakServer/global/auth/PrincipalHandler.java
@@ -20,7 +20,7 @@ public class PrincipalHandler {
             final Object principal
     ) {
         if (principal.toString().equals(ANONYMOUS_USER)) {
-            throw new CustomException(ErrorType.EMPTY_PRINCIPLE_ERROR);
+            throw new CustomException(ErrorType.EMPTY_PRINCIPAL_ERROR);
         }
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -32,13 +32,15 @@ public enum ErrorType {
     JSON_TO_MAP_ERROR(HttpStatus.BAD_REQUEST, "40017", "JSON 문자열을 Map으로 변환하는 중 오류가 발생했습니다."),
     UNIV_CERT_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "40018", "이미 인증이 완료 이메일입니다."),
     SAME_MEMBER_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40019", "자기 자신에게는 약속을 신청할 수 없습니다."),
+    NOT_MEMBERS_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40020", "해당 회원의 약속이 아닙니다"),
+
 
     // S3 관련 오류
     IMAGE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "40051", "이미지 확장자는 jpg, png, webp만 가능합니다."),
     IMAGE_SIZE_ERROR(HttpStatus.BAD_REQUEST, "40052", "이미지 사이즈는 5MB를 넘을 수 없습니다."),
 
     // 인증 관련 오류
-    EMPTY_PRINCIPLE_ERROR(HttpStatus.BAD_REQUEST, "40076", "Principle 객체가 없습니다. (null)"),
+    EMPTY_PRINCIPAL_ERROR(HttpStatus.BAD_REQUEST, "40076", "Principal 객체가 없습니다. (null)"),
 
     /**
      * 401 UNAUTHORIZED
@@ -50,7 +52,7 @@ public enum ErrorType {
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "40105", "잘못된 JWT 서명입니다."),
     UNKNOWN_JWT_ERROR(HttpStatus.UNAUTHORIZED, "40106", "알 수 없는 JWT 토큰 오류가 발생했습니다."),
 
-    INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "40107", "유효하지 않은 소셜 엑세스 토큰입니다."),
+    INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "40107", "유효하지 않은 소셜 액세스 토큰입니다."),
     EXPIRED_AUTHENTICATION_CODE(HttpStatus.UNAUTHORIZED, "40108", "인가 코드가 만료되었습니다."),
     UN_LOGIN_ERROR(HttpStatus.UNAUTHORIZED, "40109", "로그인 후 진행해주세요."),
 
@@ -62,6 +64,7 @@ public enum ErrorType {
     NOT_FOUND_CREDENTIALS_JSON_ERROR(HttpStatus.NOT_FOUND, "40403", "구글미트 Credentials Json 파일을 찾을 수 없습니다."),
     NOT_FOUND_SENIOR_BY_MEMBER(HttpStatus.NOT_FOUND, "40404", "해당 ID를 가진 멤버와 매핑된 선배를 찾을 수 없습니다."),
     NOT_FOUND_SENIOR_ERROR(HttpStatus.NOT_FOUND, "40405", "존재하지 않는 선배입니다."),
+    NOT_FOUND_GOOGLE_MEET_LINK_ERROR(HttpStatus.NOT_FOUND, "40407", "구글 미트 링크가 존재하지 않는 약속입니다."),
 
     /**
      * 409 CONFLICT


### PR DESCRIPTION
# 💡 Issue
- resolved: #84 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->

- 구글 미트 링크가 없는 약속 (확정 대기, 거절 약속 등)일 때 예외 처리를 하였습니다.

<img width="422" alt="image" src="https://github.com/user-attachments/assets/2a7e13c4-33ca-4e54-bbc8-ed6fa64698d7">

- 액세스 토큰에서 획득한 멤버 Id를 리퀘스트 바디에 적은 약속 Id 안의 후배의 멤버 Id, 선배의 멤버 Id와 비교하여 둘 모두와 다를 경우에 대한 예외 처리를 하였습니다.

<img width="344" alt="image" src="https://github.com/user-attachments/assets/d2e6f881-ce1a-4a57-9b78-3425a22cd933">

- 정상 응답

<img width="392" alt="image" src="https://github.com/user-attachments/assets/4dc3ea65-af15-4b06-994c-d1bbed357187">


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- Spring Data JPA에서 query 어노테이션을 사용해 JPQL 쿼리를 작성하였습니다.