### PR TITLE
[FEAT] #86 - 선배 상세 프로필 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileResponse;
 import org.sopt.seonyakServer.domain.senior.model.PreferredTimeList;
 import org.sopt.seonyakServer.domain.senior.service.SeniorService;
 import org.springframework.http.ResponseEntity;
@@ -43,5 +44,12 @@ public class SeniorController {
             @RequestParam(required = false) final List<String> position
     ) {
         return ResponseEntity.ok(seniorService.searchSeniorFieldPosition(field, position));
+    }
+
+    @GetMapping("/{seniorId}")
+    public ResponseEntity<SeniorProfileResponse> getSeniorProfile(
+            @PathVariable final Long seniorId
+    ) {
+        return ResponseEntity.ok(seniorService.getSeniorProfile(seniorId));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorProfileResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorProfileResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.seonyakServer.domain.senior.dto;
+
+public record SeniorProfileResponse(
+        String level,
+        String career,
+        String award,
+        String catchphrase,
+        String story
+) {
+    public static SeniorProfileResponse of(
+            final String level,
+            final String career,
+            final String award,
+            final String catchphrase,
+            final String story
+    ) {
+        return new SeniorProfileResponse(
+                level,
+                career,
+                award,
+                catchphrase,
+                story
+        );
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileResponse;
 import org.sopt.seonyakServer.domain.senior.model.PreferredTimeList;
 import org.sopt.seonyakServer.domain.senior.model.Senior;
 import org.sopt.seonyakServer.domain.senior.repository.SeniorRepository;
@@ -44,5 +45,18 @@ public class SeniorService {
     @Transactional(readOnly = true)
     public List<SeniorListResponse> searchSeniorFieldPosition(List<String> field, List<String> position) {
         return seniorRepository.searchSeniorFieldPosition(field, position);
+    }
+
+    @Transactional(readOnly = true)
+    public SeniorProfileResponse getSeniorProfile(final Long seniorId) {
+        Senior senior = seniorRepository.findSeniorByIdOrThrow(seniorId);
+
+        return SeniorProfileResponse.of(
+                senior.getLevel(),
+                senior.getCareer(),
+                senior.getAward(),
+                senior.getCatchphrase(),
+                senior.getStory()
+        );
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #86 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->

- 존재하지 않는 선배 Id를 요청했을 때

<img width="324" alt="image" src="https://github.com/user-attachments/assets/58cd5975-2dd1-4f4c-83e6-6da5b0fee0c2">

- 정상 응답

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/d2928bd2-39b3-4c63-bcb7-8003b68b2715">