### PR TITLE
[FEAT] #93 - 선배 카드 정보 조회 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
@@ -1,9 +1,16 @@
 package org.sopt.seonyakServer.domain.member.dto;
 
 public record MemberJoinResponse(
+        Long seniorId,
         String role
 ) {
-    public static MemberJoinResponse of(final String role) {
-        return new MemberJoinResponse(role);
+    public static MemberJoinResponse of(
+            final Long seniorId,
+            final String role
+    ) {
+        return new MemberJoinResponse(
+                seniorId,
+                role
+        );
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
@@ -1,5 +1,8 @@
 package org.sopt.seonyakServer.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberJoinResponse(
         Long seniorId,
         String role

--- a/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
@@ -121,4 +121,8 @@ public class Member extends BaseTimeEntity {
             this.departmentList = department;
         }
     }
+
+    public void addSenior(Senior senior) {
+        this.senior = senior;
+    }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -3,7 +3,6 @@ package org.sopt.seonyakServer.domain.member.service;
 import jakarta.annotation.PostConstruct;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -34,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -153,10 +153,13 @@ public class MemberService {
         memberRepository.save(member);
 
         if (memberJoinRequest.role().equals("SENIOR")) {
-            return MemberJoinResponse.of(seniorService.createSenior(memberJoinRequest, member));
+            seniorService.createSenior(memberJoinRequest, member);
         }
 
-        return MemberJoinResponse.of(memberJoinRequest.role());
+        return MemberJoinResponse.of(
+                member.getId(),
+                memberJoinRequest.role()
+        );
     }
 
     public void sendMessage(SendCodeRequest sendCodeRequest) {

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package org.sopt.seonyakServer.domain.member.service;
 import jakarta.annotation.PostConstruct;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -152,12 +154,13 @@ public class MemberService {
 
         memberRepository.save(member);
 
+        Long seniorId = null;
         if (memberJoinRequest.role().equals("SENIOR")) {
-            seniorService.createSenior(memberJoinRequest, member);
+            member.addSenior(seniorService.createSenior(memberJoinRequest, member));
+            seniorId = member.getSenior().getId();
         }
-
         return MemberJoinResponse.of(
-                member.getId(),
+                seniorId,
                 memberJoinRequest.role()
         );
     }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/controller/SeniorController.java
@@ -2,6 +2,7 @@ package org.sopt.seonyakServer.domain.senior.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorCardProfileResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileResponse;
@@ -51,5 +52,12 @@ public class SeniorController {
             @PathVariable final Long seniorId
     ) {
         return ResponseEntity.ok(seniorService.getSeniorProfile(seniorId));
+    }
+
+    @GetMapping("/card/{seniorId}")
+    public ResponseEntity<SeniorCardProfileResponse> getSeniorCardProfile(
+            @PathVariable final Long seniorId
+    ) {
+        return ResponseEntity.ok(seniorService.getSeniorCardProfile(seniorId));
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorCardProfileResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorCardProfileResponse.java
@@ -1,0 +1,28 @@
+package org.sopt.seonyakServer.domain.senior.dto;
+
+public record SeniorCardProfileResponse(
+        String nickname,
+        String company,
+        String filed,
+        String position,
+        String detailPosition,
+        String level
+) {
+    public static SeniorCardProfileResponse of(
+            final String nickname,
+            final String company,
+            final String filed,
+            final String position,
+            final String detailPosition,
+            final String level
+    ) {
+        return new SeniorCardProfileResponse(
+                nickname,
+                company,
+                filed,
+                position,
+                detailPosition,
+                level
+        );
+    }
+}

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorCardProfileResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/dto/SeniorCardProfileResponse.java
@@ -3,7 +3,7 @@ package org.sopt.seonyakServer.domain.senior.dto;
 public record SeniorCardProfileResponse(
         String nickname,
         String company,
-        String filed,
+        String field,
         String position,
         String detailPosition,
         String level
@@ -11,7 +11,7 @@ public record SeniorCardProfileResponse(
     public static SeniorCardProfileResponse of(
             final String nickname,
             final String company,
-            final String filed,
+            final String field,
             final String position,
             final String detailPosition,
             final String level
@@ -19,7 +19,7 @@ public record SeniorCardProfileResponse(
         return new SeniorCardProfileResponse(
                 nickname,
                 company,
-                filed,
+                field,
                 position,
                 detailPosition,
                 level

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.MemberJoinRequest;
 import org.sopt.seonyakServer.domain.member.model.Member;
+import org.sopt.seonyakServer.domain.senior.dto.SeniorCardProfileResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileResponse;
@@ -76,6 +77,20 @@ public class SeniorService {
                 senior.getAward(),
                 senior.getCatchphrase(),
                 senior.getStory()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public SeniorCardProfileResponse getSeniorCardProfile(final Long seniorId) {
+        Senior senior = seniorRepository.findSeniorByIdOrThrow(seniorId);
+
+        return SeniorCardProfileResponse.of(
+                senior.getMember().getNickname(),
+                senior.getCompany(),
+                senior.getMember().getField(),
+                senior.getPosition(),
+                senior.getDetailPosition(),
+                senior.getLevel()
         );
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -25,7 +25,7 @@ public class SeniorService {
     private final PrincipalHandler principalHandler;
 
     @Transactional
-    public String createSenior(final MemberJoinRequest memberJoinRequest, Member member) {
+    public void createSenior(final MemberJoinRequest memberJoinRequest, Member member) {
 
         Senior senior = Senior.create(
                 member,
@@ -37,8 +37,6 @@ public class SeniorService {
         );
 
         seniorRepository.save(senior);
-
-        return memberJoinRequest.role();
     }
 
     @Transactional

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.dto.MemberJoinRequest;
 import org.sopt.seonyakServer.domain.member.model.Member;
+import org.sopt.seonyakServer.domain.member.repository.MemberRepository;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorCardProfileResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorListResponse;
 import org.sopt.seonyakServer.domain.senior.dto.SeniorProfileRequest;
@@ -21,11 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SeniorService {
 
+    private final MemberRepository memberRepository;
     private final SeniorRepository seniorRepository;
     private final PrincipalHandler principalHandler;
 
     @Transactional
-    public void createSenior(final MemberJoinRequest memberJoinRequest, Member member) {
+    public Senior createSenior(final MemberJoinRequest memberJoinRequest, Member member) {
 
         Senior senior = Senior.create(
                 member,
@@ -36,7 +38,7 @@ public class SeniorService {
                 memberJoinRequest.level()
         );
 
-        seniorRepository.save(senior);
+        return seniorRepository.save(senior);
     }
 
     @Transactional


### PR DESCRIPTION
# 💡 Issue
- resolved: #93

# 📄 Description
* 회원가입 플로우에서 등록한 선배의 카드 정보를 조회하는 API 입니다.
* 회원가입 시, 선배일경우에는 응답에 SeniorId값을 추가로 반환해주도록 했습니다.(프로필 등록 시 필요)