### PR TITLE
[FEAT] #101 - 약속 수락/거절 시 문자 발송 구현 및 오류 해결

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/controller/AppointmentController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/controller/AppointmentController.java
@@ -1,6 +1,7 @@
 package org.sopt.seonyakServer.domain.appointment.controller;
 
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentAcceptRequest;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentDetailResponse;
@@ -34,7 +35,7 @@ public class AppointmentController {
 
     @PatchMapping("/appointment/accept")
     public ResponseEntity<Void> acceptAppointment(
-            @RequestBody AppointmentAcceptRequest appointmentAcceptRequest
+            @Valid @RequestBody AppointmentAcceptRequest appointmentAcceptRequest
     ) {
         appointmentService.acceptAppointment(appointmentAcceptRequest);
         return ResponseEntity.ok().build();
@@ -42,7 +43,7 @@ public class AppointmentController {
 
     @PatchMapping("/appointment/reject")
     public ResponseEntity<Void> rejectAppointment(
-            @RequestBody AppointmentRejectRequest appointmentRejectRequest
+            @Valid @RequestBody AppointmentRejectRequest appointmentRejectRequest
     ) {
         appointmentService.rejectAppointment(appointmentRejectRequest);
         return ResponseEntity.ok().build();

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentAcceptRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentAcceptRequest.java
@@ -1,15 +1,19 @@
 package org.sopt.seonyakServer.domain.appointment.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import org.sopt.seonyakServer.domain.appointment.model.DataTimeRange;
 
 public record AppointmentAcceptRequest(
-        @NotBlank(message = "약속 Id는 공백일 수 없습니다.")
+        @NotNull(message = "약속 Id는 공백일 수 없습니다.")
+        @Positive(message = "약속 Id는 양수여야 합니다.")
         Long appointmentId,
         @NotBlank(message = "구글 미트 링크는 공백일 수 없습니다.")
         String googleMeetLink,
-        @NotBlank(message = "timeList는 공백일 수 없습니다.")
+        @NotEmpty(message = "timeList는 공백일 수 없습니다.")
         List<DataTimeRange> timeList
 ) {
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentAcceptRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentAcceptRequest.java
@@ -1,11 +1,15 @@
 package org.sopt.seonyakServer.domain.appointment.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.sopt.seonyakServer.domain.appointment.model.DataTimeRange;
 
 public record AppointmentAcceptRequest(
+        @NotBlank(message = "약속 Id는 공백일 수 없습니다.")
         Long appointmentId,
+        @NotBlank(message = "구글 미트 링크는 공백일 수 없습니다.")
         String googleMeetLink,
+        @NotBlank(message = "timeList는 공백일 수 없습니다.")
         List<DataTimeRange> timeList
 ) {
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentRejectRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentRejectRequest.java
@@ -1,7 +1,11 @@
 package org.sopt.seonyakServer.domain.appointment.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record AppointmentRejectRequest(
+        @NotBlank(message = "약속 Id는 공백일 수 없습니다.")
         Long appointmentId,
+        @NotBlank(message = "거절 사유는 공백일 수 없습니다.")
         String rejectReason,
         String rejectDetail
 ) {

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentRejectRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentRejectRequest.java
@@ -1,9 +1,12 @@
 package org.sopt.seonyakServer.domain.appointment.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record AppointmentRejectRequest(
-        @NotBlank(message = "약속 Id는 공백일 수 없습니다.")
+        @NotNull(message = "약속 Id는 공백일 수 없습니다.")
+        @Positive(message = "약속 Id는 양수여야 합니다.")
         Long appointmentId,
         @NotBlank(message = "거절 사유는 공백일 수 없습니다.")
         String rejectReason,

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -1,8 +1,13 @@
 package org.sopt.seonyakServer.domain.appointment.service;
 
+import jakarta.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentAcceptRequest;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentDetailResponse;
 import org.sopt.seonyakServer.domain.appointment.dto.AppointmentRejectRequest;
@@ -20,6 +25,7 @@ import org.sopt.seonyakServer.domain.senior.repository.SeniorRepository;
 import org.sopt.seonyakServer.global.auth.PrincipalHandler;
 import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +37,22 @@ public class AppointmentService {
     private final SeniorRepository seniorRepository;
     private final MemberRepository memberRepository;
     private final PrincipalHandler principalHandler;
+
+    private DefaultMessageService defaultMessageService;
+
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+
+    @Value("${coolsms.api.secret}")
+    private String apiSecret;
+
+    @Value("${coolsms.fromNumber}")
+    private String fromNumber;
+
+    @PostConstruct
+    public void init() {
+        this.defaultMessageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
 
     @Transactional
     public void postAppointment(AppointmentRequest appointmentRequest) {
@@ -76,6 +98,11 @@ public class AppointmentService {
                 AppointmentStatus.SCHEDULED
         );
         appointmentRepository.save(appointment);
+
+        sendNoticeMessage(
+                appointment.getMember(),
+                " 후배님의 약속 신청이 수락되었습니다.\n나의 약속에서 자세한 정보를 확인해 주세요."
+        );
     }
 
     @Transactional
@@ -96,6 +123,21 @@ public class AppointmentService {
                 AppointmentStatus.REJECTED
         );
         appointmentRepository.save(appointment);
+
+        sendNoticeMessage(
+                appointment.getMember(),
+                " 후배님의 약속 신청이 다음 사유로 인해 거절되었습니다.\n거절 사유: " + appointment.getRejectReason()
+        );
+    }
+
+    public void sendNoticeMessage(Member member, String messageDetail) {
+        Message message = new Message();
+
+        message.setFrom(fromNumber);
+        message.setTo(member.getPhoneNumber());
+        message.setText("[선약] " + member.getNickname() + messageDetail);
+
+        this.defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -88,7 +88,7 @@ public class AppointmentService {
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
 
         // 약속의 선배 Id와 토큰 Id가 일치하지 않는 경우
-        if (!Objects.equals(member.getId(), appointment.getSenior().getId())) {
+        if (!Objects.equals(member.getId(), appointment.getSenior().getMember().getId())) {
             throw new CustomException(ErrorType.NOT_AUTHORIZATION_ACCEPT);
         }
 
@@ -113,7 +113,7 @@ public class AppointmentService {
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
 
         // 약속의 선배 Id와 토큰 Id가 일치하지 않는 경우
-        if (!Objects.equals(member.getId(), appointment.getSenior().getId())) {
+        if (!Objects.equals(member.getId(), appointment.getSenior().getMember().getId())) {
             throw new CustomException(ErrorType.NOT_AUTHORIZATION_REJECT);
         }
 

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -87,6 +87,11 @@ public class AppointmentService {
         );
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
 
+        // 확정 대기 상태의 약속이 아닌 경우
+        if (appointment.getAppointmentStatus() != AppointmentStatus.PENDING) {
+            throw new CustomException(ErrorType.NOT_PENDING_APPOINTMENT_ERROR);
+        }
+
         // 약속의 선배 Id와 토큰 Id가 일치하지 않는 경우
         if (!Objects.equals(member.getId(), appointment.getSenior().getMember().getId())) {
             throw new CustomException(ErrorType.NOT_AUTHORIZATION_ACCEPT);
@@ -112,6 +117,11 @@ public class AppointmentService {
         );
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
 
+        // 확정 대기 상태의 약속이 아닌 경우
+        if (appointment.getAppointmentStatus() != AppointmentStatus.PENDING) {
+            throw new CustomException(ErrorType.NOT_PENDING_APPOINTMENT_ERROR);
+        }
+        
         // 약속의 선배 Id와 토큰 Id가 일치하지 않는 경우
         if (!Objects.equals(member.getId(), appointment.getSenior().getMember().getId())) {
             throw new CustomException(ErrorType.NOT_AUTHORIZATION_REJECT);

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -35,6 +35,8 @@ public enum ErrorType {
     NOT_MEMBERS_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40020", "해당 회원의 약속이 아닙니다."),
     NOT_VALID_OCR_IMAGE(HttpStatus.BAD_REQUEST, "40021", "이미지 인식에 실패했습니다."),
     INVALID_SAME_SENIOR(HttpStatus.BAD_REQUEST, "40022", "이미 약속을 신청한 선배입니다."),
+    NOT_PENDING_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40023", "확정 대기 약속이 아닙니다"),
+
 
     // S3 관련 오류
     IMAGE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "40051", "이미지 확장자는 jpg, png, webp만 가능합니다."),


### PR DESCRIPTION
# 💡 Issue
- resolved: #101 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 약속 수락/거절 시 후배에게 결과 문자를 발송하는 로직을 구현했습니다.
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/a6c2befeba75012181ec9c5fdac79337d46ad449/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java#L143-L151

- 요청을 보낸 유저(액세스 토큰 소유자)의 멤버 Id와 해당 약속 DB 상 선배의 멤버 Id가 아닌 선배 Id를 비교하고 있던 오류를 해결했습니다.
<img width="608" alt="image" src="https://github.com/user-attachments/assets/7ea3777d-ca27-4dda-ac2d-bf3ab1e49f18">

- 약속 수락/거절 시 확정 대기 상태의 약속이 아닐 경우 에러 처리를 추가했습니다.
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/a6c2befeba75012181ec9c5fdac79337d46ad449/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java#L90-L93

- 약속 수락/거절 시 올바르지 않은 `RequestBody`가 들어와도 success 응답이 나가던 오류(ex. 약속 거절 엔드포인트에 수락의 바디를 넣은 경우에도 success가 뜸)를 해결했습니다. (@NotBlank Valid 추가)
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/a6c2befeba75012181ec9c5fdac79337d46ad449/src/main/java/org/sopt/seonyakServer/domain/appointment/dto/AppointmentRejectRequest.java#L5-L12
