### PR TITLE
[FEAT] #113 - 중복된 학과 이름 학과 리스트에 저장하지 않는 기능 추가

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/university/service/UnivService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/university/service/UnivService.java
@@ -1,6 +1,8 @@
 package org.sopt.seonyakServer.domain.university.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.university.dto.SearchDeptResponse;
@@ -36,8 +38,10 @@ public class UnivService {
         }
 
         List<Department> departments = deptRepository.findByUnivIdAndDeptNameContaining(univName, deptName);
+        Set<String> uniqueDeptNames = new HashSet<>();
 
         return departments.stream()
+                .filter(department -> uniqueDeptNames.add(department.getDeptName()))
                 .map(department -> SearchDeptResponse.of(
                         department.getDeptName(),
                         department.isClosed())


### PR DESCRIPTION
# 💡 Issue
- resolved: #113 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 클라이언트 개발자 요청으로,  `HashSet`을 사용해 선배 온보딩 단계에서 학과 조회 시, 
폐과 여부와 관계없이 중복되는 이름을 가진 학과는 학과 리스트에 쌓이지 않도록 합니다.