### PR TITLE
[FEAT] #115 - 온보딩 시 이탈한 회원 DB를 삭제하는 스케줄링 로직 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/SeonyakServerApplication.java
+++ b/src/main/java/org/sopt/seonyakServer/SeonyakServerApplication.java
@@ -2,8 +2,10 @@ package org.sopt.seonyakServer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SeonyakServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/sopt/seonyakServer/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.seonyakServer.domain.member.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.sopt.seonyakServer.domain.member.model.Member;
 import org.sopt.seonyakServer.domain.member.model.SocialType;
@@ -21,4 +22,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         return findMemberById(id)
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_MEMBER_ERROR));
     }
+
+    // phoneNumber가 null이고 updatedAt 시간이 time만큼 보다 더 이전인 모든 Member 엔티티를 삭제
+    void deleteByPhoneNumberIsNullAndUpdatedAtBefore(LocalDateTime time);
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -63,6 +63,7 @@ public class MemberService {
     }
 
     // JWT Access Token 생성
+    @Transactional
     public LoginSuccessResponse create(
             final String authorizationCode,
             final MemberLoginRequest loginRequest
@@ -73,7 +74,7 @@ public class MemberService {
     }
 
     // 소셜 플랫폼으로부터 해당 유저 정보를 받아옴
-    public MemberInfoResponse getMemberInfoResponse(
+    private MemberInfoResponse getMemberInfoResponse(
             final String authorizationCode,
             final MemberLoginRequest loginRequest
     ) {
@@ -106,14 +107,14 @@ public class MemberService {
         }
     }
 
-    public boolean isExistingMember(
+    private boolean isExistingMember(
             final SocialType socialType,
             final String socialId
     ) {
         return memberRepository.findBySocialTypeAndSocialId(socialType, socialId).isPresent();
     }
 
-    public Long getMemberIdBySocialId(
+    private Long getMemberIdBySocialId(
             final SocialType socialType,
             final String socialId
     ) {
@@ -124,13 +125,14 @@ public class MemberService {
         return member.getId();
     }
 
-    public LoginSuccessResponse getTokenByMemberId(final Long id) {
+    private LoginSuccessResponse getTokenByMemberId(final Long id) {
         MemberAuthentication memberAuthentication = new MemberAuthentication(id, null, null);
 
         return LoginSuccessResponse.of(jwtTokenProvider.issueAccessToken(memberAuthentication));
     }
 
     // 닉네임 유효성 검증
+    @Transactional(readOnly = true)
     public void validNickname(final NicknameRequest nicknameRequest) {
         if (!nicknameRequest.nickname().matches(NICKNAME_PATTERN)) { // 형식 체크
             throw new CustomException(ErrorType.INVALID_NICKNAME_ERROR);
@@ -168,6 +170,7 @@ public class MemberService {
         );
     }
 
+    @Transactional
     public void sendMessage(SendCodeRequest sendCodeRequest) {
         Message message = new Message();
 
@@ -198,6 +201,7 @@ public class MemberService {
     }
 
     // 인증번호 일치 여부 확인
+    @Transactional
     public void verifyCode(VerifyCodeRequest verifyCodeRequest) {
         String number = verifyCodeRequest.phoneNumber().replaceAll("-", "");
 

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.sopt.seonyakServer.domain.member.service;
 
 import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import net.nurigo.sdk.NurigoApp;
@@ -28,6 +29,7 @@ import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -213,5 +215,12 @@ public class MemberService {
         if (memberRepository.existsByPhoneNumber(phoneNumber)) {
             throw new CustomException(ErrorType.PHONE_NUMBER_DUP_ERROR);
         }
+    }
+
+    @Scheduled(fixedRate = 43200000) // 12시간마다 실행 (43200000 밀리초)
+    @Transactional
+    public void deleteMembersWithNullPhoneNumber() {
+        LocalDateTime oneHourAgo = LocalDateTime.now().minusMinutes(60);
+        memberRepository.deleteByPhoneNumberIsNullAndUpdatedAtBefore(oneHourAgo);
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/auth/redis/service/CodeService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/auth/redis/service/CodeService.java
@@ -14,7 +14,6 @@ public class CodeService {
 
     private final CodeRepository codeRepository;
 
-    @Transactional
     public void saveVerificationCode(
             final String phoneNumber,
             final String verificationCode
@@ -27,7 +26,6 @@ public class CodeService {
         );
     }
 
-    @Transactional(readOnly = true)
     public String findCodeByPhoneNumber(final String phoneNumber) {
         Code code = codeRepository.findByPhoneNumber(phoneNumber).orElseThrow(
                 () -> new CustomException(ErrorType.NO_VERIFICATION_REQUEST_HISTORY)


### PR DESCRIPTION
# 💡 Issue
- resolved: #115 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 온보딩 시 이탈한 회원 DB를 일정 간격으로 삭제하는 스케줄링 로직을 구현했습니다.
- 트랜잭션을 비즈니스 로직의 정합성이 보장되는 단위로 묶었습니다.
  - Transactional 어노테이션이 붙은 public 메서드의 내부에서 호출되는 private 메서드에는 자동으로 Transactional이 적용됩니다.