### PR TITLE
[FEAT] #121 - 소셜 로그인 시 분기 처리용 로직 구현

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/LoginSuccessResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/LoginSuccessResponse.java
@@ -1,9 +1,19 @@
 package org.sopt.seonyakServer.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record LoginSuccessResponse(
+        String role,
         String accessToken
 ) {
-    public static LoginSuccessResponse of(final String accessToken) {
-        return new LoginSuccessResponse(accessToken);
+    public static LoginSuccessResponse of(
+            final String role,
+            final String accessToken
+    ) {
+        return new LoginSuccessResponse(
+                role,
+                accessToken
+        );
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/repository/MemberRepository.java
@@ -18,6 +18,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
+    default Member findBySocialTypeAndSocialIdOrThrow(SocialType socialType, String socialId) {
+        return findBySocialTypeAndSocialId(socialType, socialId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_MEMBER_ERROR));
+    }
+
     default Member findMemberByIdOrThrow(Long id) {
         return findMemberById(id)
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_MEMBER_ERROR));


### PR DESCRIPTION
# 💡 Issue
- resolved: #121 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 클라 개발자의 요청으로 소셜 로그인 시 유저 ROLE을 응답에 추가로 포함하여 전달합니다.
  - 기존 회원 (후배): "JUNIOR"
  - 기존 회원 (선배): "SENIOR"
  - 온보딩 도중에 이탈한 유저: null (빈 값) -> 회원가입 로직 다시 수행
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/7ba992299028fc35155eab69c242efa3f4a444ce/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java#L96-L104