### PR TITLE
[HOTFIX] #126 - 회원가입 API 403 에러 해결

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
@@ -93,6 +93,7 @@ public class Member extends BaseTimeEntity {
     public void updateMember(
             Boolean isSubscribed,
             String nickname,
+            String image,
             String phoneNumber,
             String univName,
             String field,
@@ -103,6 +104,9 @@ public class Member extends BaseTimeEntity {
         }
         if (nickname != null) {
             this.nickname = nickname;
+        }
+        if (image != null) {
+            this.image = image;
         }
         if (phoneNumber != null) {
             this.phoneNumber = phoneNumber;

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -174,6 +174,7 @@ public class MemberService {
         member.updateMember(
                 memberJoinRequest.isSubscribed(),
                 memberJoinRequest.nickname(),
+                memberJoinRequest.image(),
                 memberJoinRequest.phoneNumber(),
                 memberJoinRequest.univName(),
                 memberJoinRequest.field(),

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/model/Senior.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/model/Senior.java
@@ -32,7 +32,7 @@ public class Senior extends BaseTimeEntity {
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
 
-    @Column(name = "business_card", nullable = false)
+    @Column(name = "business_card", nullable = false) // nullable을 true로 바꾸고 ddl create로 한 번 밀어야 함
     private String businessCard;
 
     @Column(name = "company")
@@ -66,30 +66,34 @@ public class Senior extends BaseTimeEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private Senior(
             Member member,
-            String detailPosition,
+            String businessCard,
             String company,
             String position,
+            String detailPosition,
             String level
     ) {
         this.member = member;
-        this.detailPosition = detailPosition;
+        this.businessCard = businessCard;
         this.company = company;
         this.position = position;
+        this.detailPosition = detailPosition;
         this.level = level;
     }
 
     public static Senior create(
             Member member,
-            String detailPosition,
+            String businessCard,
             String company,
             String position,
+            String detailPosition,
             String level
     ) {
         return Senior.builder()
                 .member(member)
-                .detailPosition(detailPosition)
+                .businessCard(businessCard)
                 .company(company)
                 .position(position)
+                .detailPosition(detailPosition)
                 .level(level)
                 .build();
     }

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -33,9 +33,10 @@ public class SeniorService {
 
         Senior senior = Senior.create(
                 member,
-                memberJoinRequest.detailPosition(),
+                memberJoinRequest.businessCard(),
                 memberJoinRequest.company(),
                 memberJoinRequest.position(),
+                memberJoinRequest.detailPosition(),
                 memberJoinRequest.level()
         );
 


### PR DESCRIPTION
# 💡 Issue
- resolved: #126 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 선배 회원가입 시 403 에러가 뜨길래 확인해 봤더니
- 기존에 Senior 엔티티의 businessCard 필드에 nullable이 false로 되어 있었는데
- Presigned URL을 빼면서 String으로 image를 받던 필드를 날리면서
- createSenior를 할 때 받던 businessCard도 날라갔고
- NotNull이어야 하는 필드가 null이라 403이 떴던 거였습니다.

https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/0a1d1e45087e3456f27d2ccc90a3b625e95e575a/src/main/java/org/sopt/seonyakServer/domain/senior/model/Senior.java#L35-L36

<br/>

- 그러나 nullable을 true로 바꾸어도 그대로 403 에러가 떠서 알아보니,
- nullable을 true로 바꾸어도 실제 데이터베이스 스키마에서 여전히 NOT NULL 제약 조건이 존재했습니다.
- 바꾸고 ddl create 해서 민 후 더미를 다시 쌓기에는 지금 시간이 촉박한 관계로,
- 일단 다시 이미지 필드들이 String으로 쓰레기 값이라도 받아서 저장하도록 할 수 있게 돌려놓겠습니다!

<br/>

- 해당 부분은 더미 싹 밀고 다시 쌓을 때 같이 적용시키면 될 것 같습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 테스트 꼭 하고 올려주세요 !!!!!