### PR TITLE
[HOTFIX] #128 - 소셜 로그인 응답 에러 및 회원가입 403 에러 해결

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
 
     @PatchMapping("/auth/join")
     public ResponseEntity<MemberJoinResponse> join(
-            @RequestBody MemberJoinRequest memberJoinRequest
+            @Valid @RequestBody MemberJoinRequest memberJoinRequest
     ) {
         return ResponseEntity.ok(memberService.patchMemberJoin(memberJoinRequest));
     }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
@@ -1,8 +1,10 @@
 package org.sopt.seonyakServer.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public record MemberJoinRequest(
+        @NotBlank(message = "role은 공백일 수 없습니다.")
         String role,
         Boolean isSubscribed,
         String nickname,

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -96,7 +96,7 @@ public class MemberService {
                 String role = null;
 
                 if (member.getSenior() == null) {
-                    if (member.getCreatedAt() != member.getUpdatedAt()) { // update 내역이 있을 경우 이미 가입한 사용자로 판단
+                    if (member.getPhoneNumber() != null) { // 멤버 엔티티에 전화번호가 없으면 온보딩을 완료하지 못한 것으로 간주
                         role = "JUNIOR";
                     }
                 } else {
@@ -125,7 +125,7 @@ public class MemberService {
             String role = null;
 
             if (member.getSenior() == null) {
-                if (member.getCreatedAt() != member.getUpdatedAt()) { // update 내역이 있을 경우 이미 가입한 사용자로 판단
+                if (member.getPhoneNumber() != null) { // 멤버 엔티티에 전화번호가 없으면 온보딩을 완료하지 못한 것으로 간주
                     role = "JUNIOR";
                 }
             } else {

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -184,7 +184,7 @@ public class MemberService {
         memberRepository.save(member);
 
         Long seniorId = null;
-        if (memberJoinRequest.role().equals("SENIOR")) {
+        if ("SENIOR".equals(memberJoinRequest.role())) {
             member.addSenior(seniorService.createSenior(memberJoinRequest, member));
             seniorId = member.getSenior().getId();
         }


### PR DESCRIPTION
# 💡 Issue
- resolved: #128 


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 후배인지, 온보딩이 필요한 유저인지 구별하는 부분이 `createdAt`과 `updatedAt`의 비교를 통해 이루어졌었는데, 간헐적으로 온보딩이 필요한 유저임에도 불구하고 `JUNIOR`로 뜨는 경우가 존재했습니다. 이를 해결하고자 멤버 엔티티에 휴대전화 번호가 없을 시 온보딩을 완료하지 못한 것으로 간주하는 방식으로 수정하였습니다.

<br/>

- 포스트맨 상에서는 API가 잘 작동하는 반면, 클라 개발자가 요청을 보낼 때는 자꾸 403 에러가 뜨는 상황이었습니다. 도커 컨테이너 로그를 뜯어보니 리퀘스트 바디에 role이 있음에도 볼구하고
- Request processing failed: java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "org.sopt.seonyakServer.domain.member.dto.MemberJoinRequest.role()" is null] 라고 떠 아예 빈 값이 들어올 수 없도록 처리하였습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- HOTFIX 반영을 위해 브랜치 룰을 잠시 Disabled 해놨으니 나중에 다시 Active로 바꿔주시면 감사하겠습니다.