### PR TITLE
[FEAT] #138 - 약속 신청 시에도 알림 문자 발송하도록 추가

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -83,6 +83,11 @@ public class AppointmentService {
                 appointmentRequest.personalTopic()
         );
         appointmentRepository.save(appointment);
+
+        sendNoticeMessage(
+                appointment.getSenior().getMember(),
+                "' 후배님이 약속을 신청하셨습니다."
+        );
     }
 
     @Transactional
@@ -148,7 +153,7 @@ public class AppointmentService {
 
         message.setFrom(fromNumber);
         message.setTo(member.getPhoneNumber());
-        message.setText("[선약] " + member.getNickname() + messageDetail);
+        message.setText("[선약] '" + member.getNickname() + messageDetail);
 
         this.defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
     }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -115,7 +115,7 @@ public class AppointmentService {
 
         sendNoticeMessage(
                 appointment.getMember(),
-                " 후배님의 약속 신청이 수락되었습니다.\n나의 약속에서 자세한 정보를 확인해 주세요."
+                "' 선배님이 약속을 수락하셨습니다."
         );
     }
 
@@ -144,7 +144,7 @@ public class AppointmentService {
 
         sendNoticeMessage(
                 appointment.getMember(),
-                " 후배님의 약속 신청이 다음 사유로 인해 거절되었습니다.\n거절 사유: " + appointment.getRejectReason()
+                "' 선배님이 약속을 거절하셨습니다."
         );
     }
 


### PR DESCRIPTION
# 💡 Issue
- resolved: #138 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 후배가 선배에게 약속 신청할 때에도 신청했다는 알림 문자를 발송하도록 추가했습니다.
- 라이팅 수정을 통해 약속 수락/거절 시 문자 내용이 너무 길어져 LMS로 바뀌는 문제를 해결했습니다.