### PR TITLE
[FIX] #140 - FeignErrorDecoder 로깅 추가

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/global/common/external/univcert/feign/FeignErrorDecoder.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/univcert/feign/FeignErrorDecoder.java
@@ -2,47 +2,54 @@ package org.sopt.seonyakServer.global.common.external.univcert.feign;
 
 import feign.Response;
 import feign.codec.ErrorDecoder;
-import java.io.BufferedReader;
+import feign.codec.StringDecoder;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
 
+@Slf4j
 public class FeignErrorDecoder implements ErrorDecoder {
+
+    private StringDecoder stringDecoder = new StringDecoder();
+
     @Override
     public Exception decode(String methodKey, Response response) {
 
-        // 400에러가 내려오는 경우
-        if (response.status() == 400) {
-            try (InputStream bodyStream = response.body().asInputStream()) {
-                String body = new BufferedReader(new InputStreamReader(bodyStream, StandardCharsets.UTF_8))
-                        .lines().collect(Collectors.joining("\n"));
+        String message;
+
+        if (response.body() != null) {
+            try {
+                String body = (String) stringDecoder.decode(response, String.class);
 
                 // 응답결과 JSON 파싱
                 JSONObject jsonObject = new JSONObject(body);
-                String message = jsonObject.optString("message", "Unknown error");
-
-                // 응답 메시지를 기준으로 분기처리
-                if (message.equals("대학과 일치하지 않는 메일 도메인입니다.")) {
-                    throw new CustomException(ErrorType.INVALID_EMAIL_DOMAIN_ERROR);
-                }
-                if (message.equals("이미 완료된 요청입니다.")) {
-                    throw new CustomException(ErrorType.UNIV_CERT_REQUEST_ERROR);
-                }
-                if (message.equals("인증 요청 이력이 존재하지 않습니다.")) {
-                    throw new CustomException(ErrorType.NO_VERIFICATION_REQUEST_HISTORY);
-                }
-                throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
-            } catch (IOException e) {
-                throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+                message = jsonObject.optString("message", "message 필드가 존재하지 않습니다.");
+            } catch (IOException | JSONException e) {
+                log.error(methodKey + "Feign 요청이 실패한 후 받은 Response Body를 객체로 변환하는 과정에서 오류가 발생했습니다.", e);
+                throw new CustomException(ErrorType.INTERNAL_FEIGN_ERROR);
             }
         } else {
-            // 다른 상태 코드에 대한 처리를 추가합니다.
-            return new CustomException(ErrorType.INTERNAL_FEIGN_ERROR);
+            throw new CustomException(ErrorType.NO_RESPONSE_BODY_ERROR);
         }
+
+        // 응답 메시지를 기준으로 분기처리
+        if (message.equals("대학과 일치하지 않는 메일 도메인입니다.")) {
+            throw new CustomException(ErrorType.INVALID_EMAIL_DOMAIN_ERROR);
+        }
+        if (message.equals("이미 완료된 요청입니다.")) {
+            throw new CustomException(ErrorType.UNIV_CERT_REQUEST_ERROR);
+        }
+        if (message.equals("인증 요청 이력이 존재하지 않습니다.")) {
+            throw new CustomException(ErrorType.NO_VERIFICATION_REQUEST_HISTORY);
+        }
+
+        log.error(String.valueOf(response.status()));
+        log.error(message);
+        log.error(String.valueOf(response.headers()));
+
+        throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -36,6 +36,7 @@ public enum ErrorType {
     NOT_VALID_OCR_IMAGE(HttpStatus.BAD_REQUEST, "40021", "이미지 인식에 실패했습니다."),
     INVALID_SAME_SENIOR(HttpStatus.BAD_REQUEST, "40022", "이미 약속을 신청한 선배입니다."),
     NOT_PENDING_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40023", "확정 대기 약속이 아닙니다"),
+    NO_RESPONSE_BODY_ERROR(HttpStatus.BAD_REQUEST, "40024", "Response Body가 존재하지 않습니다."),
 
 
     // S3 관련 오류


### PR DESCRIPTION
# 💡 Issue
- resolved: #140 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 구글 소셜 로그인 시 과정에서 발생하는 에러를 확인하기 위해 `FeignErrorDecoder`에 로깅을 추가하였습니다.
- Feign 라이브러리는 기본적으로 `Decoder` 인터페이스를 통해 응답을 처리할 수 있도록 지원하므로, `InputStream`을 직접 처리하는 부분을 아래와 같이 `StringDecoder`를 사용해 Response Body를 문자열로 변환하는 방식으로 변경하였습니다.
-> 코드가 간결해짐, 스트림 관리에 신경 쓸 필요가 없음!

### 이전
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/9b7b606a6786da7493f5912c370df316053953e3/src/main/java/org/sopt/seonyakServer/global/common/external/univcert/feign/FeignErrorDecoder.java#L21-L23
### 이후
https://github.com/TEAM-SEONYAK/SEONYAK-SERVER/blob/345a735b31fc909bb474cc0e7dd209c6f1929a32/src/main/java/org/sopt/seonyakServer/global/common/external/univcert/feign/FeignErrorDecoder.java#L24-L25


# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 로깅만 추가하려다 약간의 로직 변경을 하게 되어 작업 내용을 남기고자 PR을 날립니다.