### PR TITLE
[FEAT] #142 - FeignErrorDecoder에 구글 소셜 로그인 Exception 분기 추가

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -35,9 +35,9 @@ public enum ErrorType {
     NOT_MEMBERS_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40020", "해당 회원의 약속이 아닙니다."),
     NOT_VALID_OCR_IMAGE(HttpStatus.BAD_REQUEST, "40021", "이미지 인식에 실패했습니다."),
     INVALID_SAME_SENIOR(HttpStatus.BAD_REQUEST, "40022", "이미 약속을 신청한 선배입니다."),
-    NOT_PENDING_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40023", "확정 대기 약속이 아닙니다"),
+    NOT_PENDING_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40023", "확정 대기 약속이 아닙니다."),
     NO_RESPONSE_BODY_ERROR(HttpStatus.BAD_REQUEST, "40024", "Response Body가 존재하지 않습니다."),
-
+    REDIRECT_URI_MISMATCH_ERROR(HttpStatus.BAD_REQUEST, "40025", "잘못된 Redirect Uri입니다."),
 
     // S3 관련 오류
     IMAGE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "40051", "이미지 확장자는 jpg, png, webp만 가능합니다."),


### PR DESCRIPTION
# 💡 Issue
- resolved: #142 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- FeignErrorDecoder에 구글 소셜 로그인 관련 Exception 분기도 추가했습니다.
- 이제 redirect uri가 잘못됐거나 인가 코드가 만료됐을 시 클라이언트에게 해당 오류에 대한 응답 본문이 내려갑니다 !