### PR TITLE
[FIX] #144 - 간헐적 트랜잭션 오류 해결을 위한 객체 생성 로직 변경

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/model/Appointment.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/model/Appointment.java
@@ -66,7 +66,7 @@ public class Appointment extends BaseTimeEntity {
     @Column(name = "reject_detail")
     private String rejectDetail;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private Appointment(
             Member member,
             Senior senior,
@@ -81,24 +81,6 @@ public class Appointment extends BaseTimeEntity {
         this.timeList = timeList;
         this.topic = topic;
         this.personalTopic = personalTopic;
-    }
-
-    public static Appointment create(
-            Member member,
-            Senior senior,
-            AppointmentStatus appointmentStatus,
-            List<DateTimeRange> timeList,
-            List<String> topic,
-            String personalTopic
-    ) {
-        return Appointment.builder()
-                .member(member)
-                .senior(senior)
-                .appointmentStatus(appointmentStatus)
-                .timeList(timeList)
-                .topic(topic)
-                .personalTopic(personalTopic)
-                .build();
     }
 
     public void acceptAppointment(

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/model/AppointmentCard.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/model/AppointmentCard.java
@@ -37,7 +37,7 @@ public class AppointmentCard implements Comparable<AppointmentCard> {
     @JsonIgnore
     private LocalDateTime updatedAt;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private AppointmentCard(
             Long appointmentId,
             AppointmentStatus appointmentStatus,
@@ -97,47 +97,5 @@ public class AppointmentCard implements Comparable<AppointmentCard> {
 
         // 날짜가 다르면 날짜를 기준으로 비교 결과 반환
         return dateComparison;
-    }
-
-    public static AppointmentCard create(
-            Long appointmentId,
-            AppointmentStatus appointmentStatus,
-            Long seniorId,
-            String nickname,
-            String image,
-            String field,
-            String department,
-            List<String> topic,
-            String personalTopic,
-            String company,
-            String position,
-            String detailPosition,
-            String level,
-            String date,
-            String startTime,
-            String endTime,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        return AppointmentCard.builder()
-                .appointmentId(appointmentId)
-                .appointmentStatus(appointmentStatus)
-                .seniorId(seniorId)
-                .nickname(nickname)
-                .image(image)
-                .field(field)
-                .department(department)
-                .topic(topic)
-                .personalTopic(personalTopic)
-                .company(company)
-                .position(position)
-                .detailPosition(detailPosition)
-                .level(level)
-                .date(date)
-                .startTime(startTime)
-                .endTime(endTime)
-                .createdAt(createdAt)
-                .updatedAt(updatedAt)
-                .build();
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/model/JuniorInfo.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/model/JuniorInfo.java
@@ -14,7 +14,7 @@ public class JuniorInfo {
     private String field;
     private String department;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private JuniorInfo(
             String nickname,
             String univName,
@@ -25,19 +25,5 @@ public class JuniorInfo {
         this.univName = univName;
         this.field = field;
         this.department = department;
-    }
-
-    public static JuniorInfo create(
-            String nickname,
-            String univName,
-            String field,
-            String department
-    ) {
-        return JuniorInfo.builder()
-                .nickname(nickname)
-                .univName(univName)
-                .field(field)
-                .department(department)
-                .build();
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/model/SeniorInfo.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/model/SeniorInfo.java
@@ -17,7 +17,7 @@ public class SeniorInfo {
     private String detailPosition;
     private String level;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private SeniorInfo(
             String nickname,
             String image,
@@ -34,25 +34,5 @@ public class SeniorInfo {
         this.position = position;
         this.detailPosition = detailPosition;
         this.level = level;
-    }
-
-    public static SeniorInfo create(
-            String nickname,
-            String image,
-            String company,
-            String field,
-            String position,
-            String detailPosition,
-            String level
-    ) {
-        return SeniorInfo.builder()
-                .nickname(nickname)
-                .image(image)
-                .company(company)
-                .field(field)
-                .position(position)
-                .detailPosition(detailPosition)
-                .level(level)
-                .build();
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -78,14 +78,15 @@ public class AppointmentService {
             throw new CustomException(ErrorType.INVALID_SAME_SENIOR);
         }
 
-        Appointment appointment = Appointment.create(
-                member,
-                senior,
-                AppointmentStatus.PENDING,
-                appointmentRequest.timeList(),
-                appointmentRequest.topic(),
-                appointmentRequest.personalTopic()
-        );
+        Appointment appointment = Appointment.builder()
+                .member(member)
+                .senior(senior)
+                .appointmentStatus(AppointmentStatus.PENDING)
+                .timeList(appointmentRequest.timeList())
+                .topic(appointmentRequest.topic())
+                .personalTopic(appointmentRequest.personalTopic())
+                .build();
+
         appointmentRepository.save(appointment);
 
         sendNoticeMessage(
@@ -253,26 +254,26 @@ public class AppointmentService {
         }
 
         // Appointment에서 필요한 필드들을 매핑
-        return AppointmentCard.create(
-                appointment.getId(),
-                appointment.getAppointmentStatus(),
-                seniorId,
-                nickname,
-                image,
-                field,
-                department,
-                topic,
-                personalTopic,
-                company,
-                position,
-                detailPosition,
-                level,
-                date,
-                startTime,
-                endTime,
-                appointment.getCreatedAt(),
-                appointment.getUpdatedAt()
-        );
+        return AppointmentCard.builder()
+                .appointmentId(appointment.getId())
+                .appointmentStatus(appointment.getAppointmentStatus())
+                .seniorId(seniorId)
+                .nickname(nickname)
+                .image(image)
+                .field(field)
+                .department(department)
+                .topic(topic)
+                .personalTopic(personalTopic)
+                .company(company)
+                .position(position)
+                .detailPosition(detailPosition)
+                .level(level)
+                .date(date)
+                .startTime(startTime)
+                .endTime(endTime)
+                .createdAt(appointment.getCreatedAt())
+                .updatedAt(appointment.getUpdatedAt())
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -285,27 +286,28 @@ public class AppointmentService {
 
         Member member = appointment.getMember();
         Senior senior = appointment.getSenior();
+        Member seniorMember = senior.getMember();
 
         if (!userId.equals(member.getId()) && !userId.equals(senior.getMember().getId())) {
             throw new CustomException(ErrorType.NOT_MEMBERS_APPOINTMENT_ERROR);
         }
 
-        JuniorInfo juniorInfo = JuniorInfo.create(
-                member.getNickname(),
-                member.getUnivName(),
-                member.getField(),
-                member.getDepartmentList().get(0)
-        );
+        JuniorInfo juniorInfo = JuniorInfo.builder()
+                .nickname(member.getNickname())
+                .univName(member.getUnivName())
+                .field(member.getField())
+                .department(member.getDepartmentList().get(0))
+                .build();
 
-        SeniorInfo seniorInfo = SeniorInfo.create(
-                senior.getMember().getNickname(),
-                senior.getMember().getImage(),
-                senior.getCompany(),
-                senior.getMember().getField(),
-                senior.getPosition(),
-                senior.getDetailPosition(),
-                senior.getLevel()
-        );
+        SeniorInfo seniorInfo = SeniorInfo.builder()
+                .nickname(seniorMember.getNickname())
+                .image(seniorMember.getImage())
+                .company(senior.getCompany())
+                .field(seniorMember.getField())
+                .position(senior.getPosition())
+                .detailPosition(senior.getDetailPosition())
+                .level(senior.getLevel())
+                .build();
 
         return new AppointmentDetailResponse(
                 appointment.getAppointmentStatus(),

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
@@ -1,9 +1,11 @@
 package org.sopt.seonyakServer.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public record MemberJoinRequest(
-        int userType,
+        @NotBlank(message = "role 공백일 수 없습니다.")
+        String role,
         Boolean isSubscribed,
         String nickname,
         String image,

--- a/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/model/Member.java
@@ -67,7 +67,7 @@ public class Member extends BaseTimeEntity {
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Senior senior;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private Member(
             final SocialType socialType,
             final String socialId,
@@ -76,18 +76,6 @@ public class Member extends BaseTimeEntity {
         this.socialType = socialType;
         this.socialId = socialId;
         this.email = email;
-    }
-
-    public static Member create(
-            final SocialType socialType,
-            final String socialId,
-            final String email
-    ) {
-        return Member.builder()
-                .socialType(socialType)
-                .socialId(socialId)
-                .email(email)
-                .build();
     }
 
     public void updateMember(

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -110,11 +110,11 @@ public class MemberService {
                         member.getId()
                 );
             } else {
-                Member member = Member.create(
-                        memberInfoResponse.socialType(),
-                        memberInfoResponse.socialId(),
-                        memberInfoResponse.email()
-                );
+                Member member = Member.builder()
+                        .socialType(memberInfoResponse.socialType())
+                        .socialId(memberInfoResponse.socialId())
+                        .email(memberInfoResponse.email())
+                        .build();
 
                 return getTokenByMemberId(null, memberRepository.save(member).getId());
             }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -183,25 +183,20 @@ public class MemberService {
                 memberJoinRequest.field(),
                 memberJoinRequest.departmentList()
         );
+        log.info("role: " + memberJoinRequest.role());
 
         Long seniorId = null;
-        String role;
-        log.info("userType: " + memberJoinRequest.userType());
 
-        if (memberJoinRequest.userType() == 1) {
-            role = "SENIOR";
-        } else {
-            role = "JUNIOR";
-        }
-
-        if ("SENIOR".equals(role)) {
+        if ("SENIOR".equals(memberJoinRequest.role())) {
             member.addSenior(seniorService.createSenior(memberJoinRequest, member));
             seniorId = member.getSenior().getId();
+        } else if (!"JUNIOR".equals(memberJoinRequest.role())) {
+            throw new CustomException(ErrorType.INVALID_USER_TYPE_ERROR);
         }
 
         return MemberJoinResponse.of(
                 seniorId,
-                role
+                memberJoinRequest.role()
         );
     }
 

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/model/Senior.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/model/Senior.java
@@ -63,7 +63,7 @@ public class Senior extends BaseTimeEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     private PreferredTimeList preferredTimeList;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private Senior(
             Member member,
             String businessCard,
@@ -78,24 +78,6 @@ public class Senior extends BaseTimeEntity {
         this.position = position;
         this.detailPosition = detailPosition;
         this.level = level;
-    }
-
-    public static Senior create(
-            Member member,
-            String businessCard,
-            String company,
-            String position,
-            String detailPosition,
-            String level
-    ) {
-        return Senior.builder()
-                .member(member)
-                .businessCard(businessCard)
-                .company(company)
-                .position(position)
-                .detailPosition(detailPosition)
-                .level(level)
-                .build();
     }
 
     public void updateSenior(

--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -28,17 +28,16 @@ public class SeniorService {
     private final AppointmentService appointmentService;
     private final PrincipalHandler principalHandler;
 
-    @Transactional
     public Senior createSenior(final MemberJoinRequest memberJoinRequest, Member member) {
 
-        Senior senior = Senior.create(
-                member,
-                memberJoinRequest.businessCard(),
-                memberJoinRequest.company(),
-                memberJoinRequest.position(),
-                memberJoinRequest.detailPosition(),
-                memberJoinRequest.level()
-        );
+        Senior senior = Senior.builder()
+                .member(member)
+                .businessCard(memberJoinRequest.businessCard())
+                .company(memberJoinRequest.company())
+                .position(memberJoinRequest.position())
+                .detailPosition(memberJoinRequest.detailPosition())
+                .level(memberJoinRequest.level())
+                .build();
 
         return seniorRepository.save(senior);
     }
@@ -55,7 +54,6 @@ public class SeniorService {
                 seniorProfileRequest.story(),
                 seniorProfileRequest.preferredTimeList()
         );
-        seniorRepository.save(senior);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/seonyakServer/global/auth/redis/domain/Code.java
+++ b/src/main/java/org/sopt/seonyakServer/global/auth/redis/domain/Code.java
@@ -17,22 +17,12 @@ public class Code {
 
     private String verificationCode;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private Code(
             final String phoneNumber,
             final String verificationCode
     ) {
         this.phoneNumber = phoneNumber;
         this.verificationCode = verificationCode;
-    }
-
-    public static Code createCode(
-            final String phoneNumber,
-            final String verificationCode
-    ) {
-        return Code.builder()
-                .phoneNumber(phoneNumber)
-                .verificationCode(verificationCode)
-                .build();
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/global/auth/redis/service/CodeService.java
+++ b/src/main/java/org/sopt/seonyakServer/global/auth/redis/service/CodeService.java
@@ -6,7 +6,6 @@ import org.sopt.seonyakServer.global.auth.redis.repository.CodeRepository;
 import org.sopt.seonyakServer.global.exception.enums.ErrorType;
 import org.sopt.seonyakServer.global.exception.model.CustomException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +18,10 @@ public class CodeService {
             final String verificationCode
     ) {
         codeRepository.save(
-                Code.createCode(
-                        phoneNumber,
-                        verificationCode
-                )
+                Code.builder()
+                        .phoneNumber(phoneNumber)
+                        .verificationCode(verificationCode)
+                        .build()
         );
     }
 
@@ -33,8 +32,7 @@ public class CodeService {
 
         return code.getVerificationCode();
     }
-
-    @Transactional
+    
     public void deleteVerificationCode(final String phoneNumber) {
         Code code = codeRepository.findByPhoneNumber(phoneNumber).orElseThrow(
                 () -> new CustomException(ErrorType.NO_VERIFICATION_REQUEST_HISTORY)

--- a/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Service.java
+++ b/src/main/java/org/sopt/seonyakServer/global/common/external/s3/S3Service.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.seonyakServer.domain.member.model.Member;
 import org.sopt.seonyakServer.domain.member.repository.MemberRepository;
-import org.sopt.seonyakServer.domain.senior.model.Senior;
 import org.sopt.seonyakServer.domain.senior.repository.SeniorRepository;
 import org.sopt.seonyakServer.global.auth.PrincipalHandler;
 import org.sopt.seonyakServer.global.common.external.s3.dto.PreSignedUrlResponse;
@@ -113,9 +112,15 @@ public class S3Service {
         String uuidFileName = UUID.randomUUID().toString() + ".jpg";
         // 경로 + 파일 이름
         String key = businessPath + uuidFileName;
-        Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
-        Senior senior = seniorRepository.findSeniorByIdOrThrow(member.getSenior().getId());
-        senior.addBusinessCard("https://" + bucketName + s3Substring + key);
+
+        /**
+         * 회원가입 도중이라 Senior 엔티티가 아직 DB에 추가되지 않았음에도 해당 엔티티의 id를 참조하므로 NullPointerException 발생,
+         * Presigned URL 구현 이전 임시 용도로 구성된 API로 구현 완료 시 사용하지 않게 될 API이므로 수정하기보단 주석 처리를 해놓겠습니다
+         */
+//        Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
+//        Senior senior = seniorRepository.findSeniorByIdOrThrow(member.getSenior().getId());
+//        senior.addBusinessCard("https://" + bucketName + s3Substring + key);
+
         try {
             PutObjectRequest request = PutObjectRequest.builder()
                     .bucket(bucketName)

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -38,6 +38,7 @@ public enum ErrorType {
     NOT_PENDING_APPOINTMENT_ERROR(HttpStatus.BAD_REQUEST, "40023", "확정 대기 약속이 아닙니다."),
     NO_RESPONSE_BODY_ERROR(HttpStatus.BAD_REQUEST, "40024", "Response Body가 존재하지 않습니다."),
     REDIRECT_URI_MISMATCH_ERROR(HttpStatus.BAD_REQUEST, "40025", "잘못된 Redirect Uri입니다."),
+    INVALID_USER_TYPE_ERROR(HttpStatus.BAD_REQUEST, "40026", "유효하지 않은 User Type입니다."),
 
     // S3 관련 오류
     IMAGE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "40051", "이미지 확장자는 jpg, png, webp만 가능합니다."),


### PR DESCRIPTION
# 💡 Issue
- resolved: #144 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 현재 회원가입 API에서 선배로 회원가입에 성공해도 간헐적으로 DB에 선배 엔티티가 추가 안되는 현상이 발생하는데, 이를 해결하기 위해 전반적인 객체 생성 로직을 변경하였습니다.
(static으로 선언한 create 메서드 사용에서 -> 빌더의 접근 수준을 public으로 열고, 이를 Service에서 사용하도록 변경,
이렇게 해도 new를 이용한 객체 생성은 여전히 private으로 막혀있습니다.)

~- 또한 해당 수정으로 문제가 해결되지 않을 것에 대비해 로깅도 같이 추가하였습니다. 로깅은 추후 삭제하겠습니다.~

~- 추가로, 더티 체킹이 먹지 않는 건가 싶어 save()도 같이 넣어놨습니다. 테스트를 통해 불필요한 부분이라면 마찬가지로 삭제하겠습니다.~

**_-> 클라 측에서 Request Body를 통으로 한 번 감싸서 보내주고 있었습니다 ..! 이슈 해결 .._**

- 클라 측 요청으로 회원가입 시 내려주는 userType 필드의 타입과 변수명을 String, role로 다시 돌려놓았습니다.

- 명함 사진 업로드 API에서 NullPointerException이 발생하는 부분을 주석 처리하였습니다.