### PR TITLE
[FEAT] #150 - 약속 신청 고민 작성/선택 중복 입력, 선택 안함 방지

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -37,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AppointmentService {
 
     private final AppointmentRepository appointmentRepository;
@@ -64,8 +62,6 @@ public class AppointmentService {
     @Transactional
     public void postAppointment(AppointmentRequest appointmentRequest) {
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
-        log.info("member id: " + principalHandler.getUserIdFromPrincipal());
-        log.info("senior id: " + appointmentRequest.seniorId());
         Senior senior = seniorRepository.findSeniorByIdOrThrow(appointmentRequest.seniorId());
 
         // 자기 자신에게 약속을 신청하는 경우

--- a/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/appointment/service/AppointmentService.java
@@ -74,6 +74,18 @@ public class AppointmentService {
             throw new CustomException(ErrorType.INVALID_SAME_SENIOR);
         }
 
+        // 두 고민이 전부 넘어온 경우
+        if ((appointmentRequest.topic() != null && !appointmentRequest.topic().isEmpty()) && (
+                appointmentRequest.personalTopic() != null && !appointmentRequest.personalTopic().isBlank())) {
+            throw new CustomException(ErrorType.INVALID_BOTH_TOPICS_PROVIDED);
+        }
+
+        // 두 고민이 전부 빈 값인 경우
+        if ((appointmentRequest.topic() == null || appointmentRequest.topic().isEmpty()) && (
+                appointmentRequest.personalTopic() == null || appointmentRequest.personalTopic().isBlank())) {
+            throw new CustomException(ErrorType.INVALID_NO_TOPIC_PROVIDED);
+        }
+
         Appointment appointment = Appointment.builder()
                 .member(member)
                 .senior(senior)

--- a/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/seonyakServer/global/exception/enums/ErrorType.java
@@ -39,6 +39,8 @@ public enum ErrorType {
     NO_RESPONSE_BODY_ERROR(HttpStatus.BAD_REQUEST, "40024", "Response Body가 존재하지 않습니다."),
     REDIRECT_URI_MISMATCH_ERROR(HttpStatus.BAD_REQUEST, "40025", "잘못된 Redirect Uri입니다."),
     INVALID_USER_TYPE_ERROR(HttpStatus.BAD_REQUEST, "40026", "유효하지 않은 User Type입니다."),
+    INVALID_BOTH_TOPICS_PROVIDED(HttpStatus.BAD_REQUEST, "40027", "고민은 선택/작성 중 하나만 골라야 합니다."),
+    INVALID_NO_TOPIC_PROVIDED(HttpStatus.BAD_REQUEST, "40028", "고민은 선택/작성 중 하나는 골라야 합니다."),
 
     // S3 관련 오류
     IMAGE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "40051", "이미지 확장자는 jpg, png, webp만 가능합니다."),


### PR DESCRIPTION
# 💡 Issue
- resolved: #150 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 약속 신청 시 고민 내용을 둘 다 선택하지 않거나, 둘다 보내는 경우의 예외처리 로직을 추가했습니다.
