### PR TITLE
[FIX] #160 - 회원가입 시 반드시 필요한 필드들 NotNull 처리

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinRequest.java
@@ -1,18 +1,27 @@
 package org.sopt.seonyakServer.domain.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record MemberJoinRequest(
         @NotBlank(message = "role은 공백일 수 없습니다.")
         String role,
+        @NotNull(message = "isSubscribed는 null일 수 없습니다.")
         Boolean isSubscribed,
+        @NotBlank(message = "nickname은 공백일 수 없습니다.")
         String nickname,
+        @NotNull(message = "image는 null일 수 없습니다.")
         String image,
+        @NotBlank(message = "phoneNumber는 공백일 수 없습니다.")
         String phoneNumber,
+        @NotBlank(message = "univName은 공백일 수 없습니다.")
         String univName,
+        @NotBlank(message = "field는 공백일 수 없습니다.")
         String field,
-        List<String> departmentList,
+        @NotEmpty(message = "departmentList는 비어 있을 수 없습니다.")
+        List<@NotBlank String> departmentList,
         String businessCard,
         String company,
         String position,

--- a/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/dto/MemberJoinResponse.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberJoinResponse(
         Long seniorId,
-        String userType
+        String role
 ) {
     public static MemberJoinResponse of(
             final Long seniorId,
-            final String userType
+            final String role
     ) {
         return new MemberJoinResponse(
                 seniorId,
-                userType
+                role
         );
     }
 }

--- a/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/member/service/MemberService.java
@@ -177,10 +177,14 @@ public class MemberService {
     public MemberJoinResponse patchMemberJoin(MemberJoinRequest memberJoinRequest) {
         Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
 
+        String image = memberJoinRequest.image().isEmpty()
+                ? (Math.random() < 0.5 ? "basic1.jpg" : "basic2.jpg")
+                : memberJoinRequest.image();
+
         member.updateMember(
                 memberJoinRequest.isSubscribed(),
                 memberJoinRequest.nickname(),
-                "https://" + bucketName + s3Substring + "profiles/" + memberJoinRequest.image(),
+                "https://" + bucketName + s3Substring + "profiles/" + image,
                 memberJoinRequest.phoneNumber().replaceAll("-", ""),
                 memberJoinRequest.univName(),
                 memberJoinRequest.field(),


### PR DESCRIPTION
# 💡 Issue
- resolved: #160 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 혼용되던 role, userType 필드명을 role로 통일했습니다.
- 회원가입 시 반드시 필요한 필드들을 NotNull 처리했습니다.
- 회원가입 시 프로필 이미지를 바꾸지 않은 유저에게 기본 이미지를 매핑하는 로직을 추가했습니다.