### PR TITLE
[FIX/#164] 선배 카드 정보 조회 시 잘못된 이미지 필드를 반환하는 오류 수정

### DIFF
--- a/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
+++ b/src/main/java/org/sopt/seonyakServer/domain/senior/service/SeniorService.java
@@ -97,7 +97,6 @@ public class SeniorService {
 
     @Transactional(readOnly = true)
     public SeniorCardProfileResponse getSeniorCardProfile(final Long seniorId) {
-        Member member = memberRepository.findMemberByIdOrThrow(principalHandler.getUserIdFromPrincipal());
         Senior senior = seniorRepository.findSeniorByIdOrThrow(seniorId);
 
         return SeniorCardProfileResponse.of(
@@ -107,7 +106,7 @@ public class SeniorService {
                 senior.getPosition(),
                 senior.getDetailPosition(),
                 senior.getLevel(),
-                member.getImage()
+                senior.getMember().getImage()
         );
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #164 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 선배 카드 정보 조회 시 선배의 프로필 이미지를 반환해야 하는데, 조회하는 후배의 이미지를 반환하고 있던 오류를 수정했습니다.